### PR TITLE
Fix double form submission

### DIFF
--- a/public/css/cinode-recruitment-public.css
+++ b/public/css/cinode-recruitment-public.css
@@ -44,6 +44,11 @@ textarea {
 
 #submit {width: 100%;}
 
+#submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .block, .header.header-icon {
     margin-bottom: 5px;
 }

--- a/public/js/cinode-recruitment-public.js
+++ b/public/js/cinode-recruitment-public.js
@@ -36,6 +36,10 @@ jQuery(document).ready(function ($) {
     event.preventDefault();
     var currentForm = $(this);
 
+    // Disable submit button to prevent double submissions
+    var submitButton = currentForm.find("#submit");
+    submitButton.prop("disabled", true);
+    
     currentForm.find(".spinner").show();
     const email = currentForm.find("#email-input");
     const first_name = currentForm.find("#first_name-input");
@@ -106,10 +110,14 @@ jQuery(document).ready(function ($) {
         submitRequest(formData, currentForm);
       } else {
         currentForm.find(".spinner").hide();
+        // Re-enable submit button if validation fails
+        currentForm.find("#submit").prop("disabled", false);
       }
     } else {
       currentForm.find("#terms-validate").show();
       currentForm.find(".spinner").hide();
+      // Re-enable submit button if terms not accepted
+      currentForm.find("#submit").prop("disabled", false);
     }
 
     function validateRequiredInputs() {
@@ -168,19 +176,35 @@ jQuery(document).ready(function ($) {
             currentForm.find("input:checkbox").removeAttr("checked");
             currentForm.find(":input").not(":button, :submit, :reset, :hidden").val("");
             currentForm.find("#file-name").text("");
+            // Re-enable submit button after successful submission
+            currentForm.find("#submit").prop("disabled", false);
           } else if (response.response.code == 401) {
             currentForm.find("#unsuccessful-submit-msg").show(300);
             setTimeout(function () {
               currentForm.find("#unsuccessful-submit-msg").fadeOut("fast");
             }, 6000);
             currentForm.find(".spinner").hide();
+            // Re-enable submit button after error
+            currentForm.find("#submit").prop("disabled", false);
           }else{
             currentForm.find("#unsuccessful-submit-msg").show(300);
             setTimeout(function () {
               currentForm.find("#unsuccessful-submit-msg").fadeOut("fast");
             }, 6000);
             currentForm.find(".spinner").hide();
+            // Re-enable submit button after error
+            currentForm.find("#submit").prop("disabled", false);
           }
+        },
+        error: function (xhr, status, error) {
+          // Handle AJAX errors (network issues, server errors, etc.)
+          currentForm.find(".spinner").hide();
+          currentForm.find("#unsuccessful-submit-msg").show(300);
+          setTimeout(function () {
+            currentForm.find("#unsuccessful-submit-msg").fadeOut("fast");
+          }, 6000);
+          // Re-enable submit button after error
+          currentForm.find("#submit").prop("disabled", false);
         },
       });
     }


### PR DESCRIPTION
Fixes #16 

This pull request improves the user experience and reliability of the form submission process by preventing double submissions and ensuring the submit button is properly re-enabled after validation failures or errors. The changes span both the frontend JavaScript and CSS to provide visual feedback and robust button state management.

**Form submission reliability:**

* Disables the submit button immediately upon form submission to prevent double submissions, and ensures it is re-enabled after validation failures, unsuccessful submissions, or AJAX errors in `public/js/cinode-recruitment-public.js`. [[1]](diffhunk://#diff-521639b358189178bab79e29b4e72408b4c392a0e8b2baa873c07f68eaf4a677R39-R42) [[2]](diffhunk://#diff-521639b358189178bab79e29b4e72408b4c392a0e8b2baa873c07f68eaf4a677R113-R120) [[3]](diffhunk://#diff-521639b358189178bab79e29b4e72408b4c392a0e8b2baa873c07f68eaf4a677R179-R208)

**Visual feedback improvements:**

* Updates the CSS for the submit button in `public/css/cinode-recruitment-public.css` to show reduced opacity and a "not-allowed" cursor when disabled, providing clear feedback to users.