### PR TITLE
Feature/recruitment updates

### DIFF
--- a/admin/class-cinode-recruitment-admin.php
+++ b/admin/class-cinode-recruitment-admin.php
@@ -61,18 +61,6 @@ class Cinode_Recruitment_Admin {
 	 */
 	public function enqueue_styles() {
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Cinode_Recruitment_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Cinode_Recruitment_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
 		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/cinode-recruitment-admin.css', array(), $this->version, 'all' );
 
 	}
@@ -84,18 +72,6 @@ class Cinode_Recruitment_Admin {
 	 */
 	public function enqueue_scripts() {
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Cinode_Recruitment_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Cinode_Recruitment_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/cinode-recruitment-admin.js', array( 'jquery' ), $this->version, false );
 
 	}
@@ -105,10 +81,10 @@ function cinode_recruitment_create_menu()
 {
 
 	$iconUrl = plugin_dir_url(__FILE__) . '../images/icon-24x24.png';
-	//create new top-level menu
+	// Create new top-level menu
 	add_menu_page('Cinode Recruitment Plugin Page', 'Cinode Recruitment Plugin', 'manage_options', 'cinode_recruitment_main_menu', 'cinode_recruitment_settings_page', $iconUrl);
 
-	//call register settings function
+	// Call register settings function
 	add_action('admin_init', 'cinode_recruitment_register_settings');
 }
 add_action('admin_menu', 'cinode_recruitment_create_menu');
@@ -116,126 +92,717 @@ add_action('admin_menu', 'cinode_recruitment_create_menu');
 function cinode_recruitment_register_settings()
 {
 
-	//register our settings
+	// Register our settings
 	register_setting('cinode_recruitment-settings-group', 'cinode_recruitment_options', 'cinode_recruitment_sanitize_options');
 	register_setting('cinode_recruitment-settings-mail', 'cinode_recruitment_options_sendmail', 'cinode_recruitment_sanitize_options_sendmail');	
 }
 
 function cinode_recruitment_sanitize_options($input)
 {
+	$existing = get_option('cinode_recruitment_options', array());
 
-	$input['option_companyId']  = sanitize_text_field($input['option_companyId']);
-	$input['option_apiKey'] =  sanitize_text_field($input['option_apiKey']);
+	$input['option_companyId'] = sanitize_text_field($input['option_companyId'] ?? '');
 
+	// Preserve the existing API key when the masked placeholder '***' is submitted.
+	if (isset($input['option_apiKey']) && $input['option_apiKey'] === '***') {
+		$input['option_apiKey'] = $existing['option_apiKey'] ?? '';
+	} else {
+		$input['option_apiKey'] = sanitize_text_field($input['option_apiKey'] ?? '');
+	}
+
+	$input['option_show_subcontractor_groups']         = isset($input['option_show_subcontractor_groups']) ? 1 : 0;
+	$raw_group_ids = $input['option_subcontractor_group_ids'] ?? '';
+	if (is_array($raw_group_ids)) {
+		$input['option_subcontractor_group_ids'] = implode(',', array_filter(array_map('intval', $raw_group_ids)));
+	} else {
+		$input['option_subcontractor_group_ids'] = sanitize_text_field($raw_group_ids);
+	}
+	$allowed_selections                                = array('single', 'multiple');
+	$raw_selection                                     = $input['option_subcontractor_group_selection'] ?? 'single';
+	$input['option_subcontractor_group_selection']     = in_array($raw_selection, $allowed_selections, true) ? $raw_selection : 'single';
+	$input['option_subcontractor_default_language_id'] = intval($input['option_subcontractor_default_language_id'] ?? 1);
+	$input['option_cv_required']                       = isset($input['option_cv_required']) ? 1 : 0;
+	$input['option_parse_cv']                          = isset($input['option_parse_cv']) ? 1 : 0;
+	$raw_auto_ids = $input['option_auto_subcontractor_group_ids'] ?? '';
+	if (is_array($raw_auto_ids)) {
+		$input['option_auto_subcontractor_group_ids'] = implode(',', array_filter(array_map('intval', $raw_auto_ids)));
+	} else {
+		$input['option_auto_subcontractor_group_ids'] = sanitize_text_field($raw_auto_ids);
+	}
 
 	return $input;
 }
 function cinode_recruitment_sanitize_options_sendmail($input)
 {
-
-	$input['option_subject']  = sanitize_text_field($input['option_subject']);
-	$input['option_message'] =  sanitize_text_field($input['option_message']);
-
+	$input['option_subject'] = sanitize_text_field($input['option_subject'] ?? '');
+	$input['option_message'] = sanitize_textarea_field($input['option_message'] ?? '');
 
 	return $input;
 }
 
+function cinode_recruitment_admin_fetch_groups()
+{
+	$opts      = get_option('cinode_recruitment_options', array());
+	$companyId = $opts['option_companyId'] ?? '';
+	$token     = $opts['option_apiKey'] ?? '';
+
+	if (empty($companyId) || empty($token)) {
+		return array();
+	}
+
+	$cache_key = 'cinode_admin_groups_' . md5((string) $companyId . $token);
+	$cached    = get_transient($cache_key);
+	if ($cached !== false) {
+		return $cached;
+	}
+
+	$url  = 'https://api.cinode.app/v0.1/companies/' . intval($companyId) . '/subcontractors/groups';
+	$args = array(
+		'headers' => array(
+			'Accept'        => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+		'timeout' => 10,
+	);
+
+	$response = wp_remote_get($url, $args);
+	if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+		return array();
+	}
+
+	$groups = json_decode(wp_remote_retrieve_body($response), true);
+	$groups = is_array($groups) ? $groups : array();
+
+	set_transient($cache_key, $groups, 5 * MINUTE_IN_SECONDS);
+
+	return $groups;
+}
+
+function cinode_recruitment_admin_fetch_languages()
+{
+	$opts  = get_option('cinode_recruitment_options', array());
+	$token = $opts['option_apiKey'] ?? '';
+
+	if (empty($token)) {
+		return array();
+	}
+
+	$cache_key = 'cinode_admin_languages_' . md5($token);
+	$cached    = get_transient($cache_key);
+	if ($cached !== false) {
+		return $cached;
+	}
+
+	$url  = 'https://api.cinode.app/v0.1/languages';
+	$args = array(
+		'headers' => array(
+			'Accept'        => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+		'timeout' => 10,
+	);
+
+	$response = wp_remote_get($url, $args);
+	if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+		return array();
+	}
+
+	$languages = json_decode(wp_remote_retrieve_body($response), true);
+	$languages = is_array($languages) ? $languages : array();
+
+	set_transient($cache_key, $languages, HOUR_IN_SECONDS);
+
+	return $languages;
+}
+
 function cinode_recruitment_settings_page()
 {
+	$cinode_opts = get_option('cinode_recruitment_options', array());
+	$api_valid   = cinode_recruitment_apiTokenCheck();
+	$apiFieldVal = $api_valid ? '***' : '';
+
+	$all_groups         = $api_valid ? cinode_recruitment_admin_fetch_groups() : array();
+	$all_languages      = $api_valid ? cinode_recruitment_admin_fetch_languages() : array();
+	$selected_group_ids = array_filter(array_map('intval', explode(',', $cinode_opts['option_subcontractor_group_ids'] ?? '')));
+	$selected_auto_ids  = array_filter(array_map('intval', explode(',', $cinode_opts['option_auto_subcontractor_group_ids'] ?? '')));
+	$selected_lang_id   = intval($cinode_opts['option_subcontractor_default_language_id'] ?? 1);
+
+	$mail_opts = get_option('cinode_recruitment_options_sendmail', array());
+	if (empty($mail_opts)) {
+		$mail_opts = array(
+			'option_subject' => 'Thanks for your application',
+			'option_message' => 'Thank you for your application. We will look into your application and get back to you soon.',
+		);
+	}
 ?>
-<div class="wrap">
-	<h2>Cinode Recruitment Plugin Settings</h2>
+<div class="wrap cinode-wrap">
 
-	<form method="post" action="options.php">
-		<?php settings_fields('cinode_recruitment-settings-group');
-		$cinode_recruitment_options = get_option('cinode_recruitment_options');
-		$activatedPlugin = '';
-		$apiFieldVal = '';
-		if (cinode_recruitment_apiTokenCheck()) {
-			$activatedPlugin = '<span style="color:green; font-weight:bold;">Plugin is Activated!</span>';
-			$apiFieldVal = '***';
-		} else{
-			$activatedPlugin = '<span style="color:red; font-weight:bold;">Plugin is not activated or API token is expired!</span>';
-		}
-		wp_nonce_field('cinode_recruitment_settings_form_save', 'cinode_recruitment_nonce_field'); ?>
-		<p>Welcome to Cinode Recruitment Plugin settings page. Set your Company ID and API token.</p>
-		<table class="form-table">
-			<tr valign="top">
-				<th scope="row">Company ID</th>
-				<td><input type="text" name="cinode_recruitment_options[option_companyId]" value="<?php echo esc_attr($cinode_recruitment_options['option_companyId']); ?>" /></td>
-			</tr>
+	<div class="cinode-page-header">
+		<h1 class="cinode-page-title">
+			<span class="dashicons dashicons-groups" aria-hidden="true"></span>
+			Cinode Recruitment
+		</h1>
+		<?php if ($api_valid) : ?>
+			<span class="cinode-badge cinode-badge--active">
+				<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span> Connected
+			</span>
+		<?php else : ?>
+			<span class="cinode-badge cinode-badge--inactive">
+				<span class="dashicons dashicons-warning" aria-hidden="true"></span> Not connected — check your API credentials
+			</span>
+		<?php endif; ?>
+	</div>
 
-			<tr valign="top">
-				<th scope="row">API Token</th>
-				<td><input type="password" name="cinode_recruitment_options[option_apiKey]" value="<?php echo $apiFieldVal ?>" /></td>
-			</tr>
+	<nav class="nav-tab-wrapper cinode-nav-tabs" aria-label="Plugin settings sections">
+		<a href="#tab-api" class="nav-tab nav-tab-active" data-tab="tab-api">
+			<span class="dashicons dashicons-admin-network" aria-hidden="true"></span>
+			<span class="cinode-tab-label">API &amp; Activation</span>
+		</a>
+		<a href="#tab-subcontractor" class="nav-tab" data-tab="tab-subcontractor">
+			<span class="dashicons dashicons-businessperson" aria-hidden="true"></span>
+			<span class="cinode-tab-label">Subcontractor &amp; CV</span>
+		</a>
+		<a href="#tab-email" class="nav-tab" data-tab="tab-email">
+			<span class="dashicons dashicons-email-alt" aria-hidden="true"></span>
+			<span class="cinode-tab-label">Email Confirmation</span>
+		</a>
+		<a href="#tab-shortcode" class="nav-tab" data-tab="tab-shortcode">
+			<span class="dashicons dashicons-editor-code" aria-hidden="true"></span>
+			<span class="cinode-tab-label">Shortcode Reference</span>
+		</a>
+		<a href="#tab-spam" class="nav-tab" data-tab="tab-spam">
+			<span class="dashicons dashicons-shield" aria-hidden="true"></span>
+			<span class="cinode-tab-label">Spam Protection</span>
+		</a>
+	</nav>
 
-		</table>
-		<p > <?php echo $activatedPlugin;  ?></p>
+	<!-- ============================================================
+	     MAIN SETTINGS FORM — API credentials + Subcontractor & CV
+	     Both tab sections share this form so saving from either tab
+	     preserves all settings in cinode_recruitment_options.
+	     ============================================================ -->
+	<form method="post" action="options.php" id="cinode-main-settings-form">
+		<?php settings_fields('cinode_recruitment-settings-group'); ?>
 
-		<p class="submit">
-			<input type="submit" class="button-primary" value="Save Changes" />
-		</p>
-	</form>
+		<!-- TAB: API & Activation -->
+		<div id="tab-api" class="cinode-tab-content">
+			<div class="postbox cinode-card">
+				<div class="postbox-header">
+					<h2 class="hndle">
+						<span class="dashicons dashicons-admin-network" aria-hidden="true"></span>
+						API Credentials
+					</h2>
+				</div>
+				<div class="inside">
+					<p>Enter your Cinode <strong>Company ID</strong> and <strong>API Token</strong> to activate the plugin. You can find these in your Cinode account settings.</p>
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">
+								<label for="cinode_company_id">Company ID</label>
+							</th>
+							<td>
+								<input
+									type="text"
+									id="cinode_company_id"
+									name="cinode_recruitment_options[option_companyId]"
+									value="<?php echo esc_attr($cinode_opts['option_companyId'] ?? ''); ?>"
+									class="regular-text"
+									placeholder="e.g. 1234"
+								/>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<label for="cinode_api_key">API Token</label>
+							</th>
+							<td>
+								<input
+									type="password"
+									id="cinode_api_key"
+									name="cinode_recruitment_options[option_apiKey]"
+									value="<?php echo esc_attr($apiFieldVal); ?>"
+									class="regular-text"
+									autocomplete="new-password"
+									placeholder="<?php echo $api_valid ? 'Token saved \u2014 enter a new value to replace it' : 'Paste your API token here'; ?>"
+								/>
+								<p class="description"><?php echo $api_valid ? 'Your token is saved. Leave the field showing <code>***</code> to keep it unchanged.' : 'Paste the token from your Cinode account.'; ?></p>
+							</td>
+						</tr>
+					</table>
+					<?php submit_button('Save API Settings', 'primary large', 'submit', true); ?>
+				</div>
+			</div>
+		</div><!-- #tab-api -->
 
+		<!-- TAB: Subcontractor & CV -->
+		<div id="tab-subcontractor" class="cinode-tab-content" style="display:none;">
 
-	<h3>How to use shortcode</h3>
+			<div class="postbox cinode-card">
+				<div class="postbox-header">
+					<h2 class="hndle">
+						<span class="dashicons dashicons-groups" aria-hidden="true"></span>
+						Subcontractor Groups
+					</h2>
+				</div>
+				<div class="inside">
+					<p>Control how the public form presents subcontractor group selection to applicants.</p>
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">Show group selector</th>
+							<td>
+								<fieldset>
+									<label for="cinode_show_groups">
+										<input
+											type="checkbox"
+											id="cinode_show_groups"
+											name="cinode_recruitment_options[option_show_subcontractor_groups]"
+											value="1"
+											<?php checked(1, $cinode_opts['option_show_subcontractor_groups'] ?? 0); ?>
+										/>
+										Enable the group selector when the form is used in subcontractor mode
+									</label>
+								</fieldset>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<label for="cinode_group_ids">Groups to display</label>
+							</th>
+							<td>
+								<?php if (!empty($all_groups)) : ?>
+									<select
+										id="cinode_group_ids"
+										name="cinode_recruitment_options[option_subcontractor_group_ids][]"
+										multiple="multiple"
+										size="<?php echo min(count($all_groups), 8); ?>"
+										style="min-width:14rem;"
+									>
+										<?php foreach ($all_groups as $grp) :
+											$grp_id   = intval($grp['id']);
+											$grp_name = esc_html($grp['name'] ?? '#' . $grp_id);
+										?>
+											<option value="<?php echo $grp_id; ?>" <?php selected(in_array($grp_id, $selected_group_ids, true)); ?>><?php echo $grp_name; ?></option>
+										<?php endforeach; ?>
+									</select>
+									<p class="description">Hold <kbd>Ctrl</kbd> / <kbd>Cmd</kbd> to select multiple groups. Leave all unselected to show every group.</p>
+								<?php else : ?>
+									<input
+										type="text"
+										id="cinode_group_ids"
+										name="cinode_recruitment_options[option_subcontractor_group_ids]"
+										value="<?php echo esc_attr($cinode_opts['option_subcontractor_group_ids'] ?? ''); ?>"
+										class="regular-text"
+										placeholder="e.g. 12,34,56"
+									/>
+									<p class="description">Comma-separated group IDs. Leave empty to show all groups.</p>
+								<?php endif; ?>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<label for="cinode_group_selection">Selection mode</label>
+							</th>
+							<td>
+								<select id="cinode_group_selection" name="cinode_recruitment_options[option_subcontractor_group_selection]">
+									<option value="single" <?php selected('single', $cinode_opts['option_subcontractor_group_selection'] ?? 'single'); ?>>Single &mdash; dropdown</option>
+									<option value="multiple" <?php selected('multiple', $cinode_opts['option_subcontractor_group_selection'] ?? 'single'); ?>>Multiple &mdash; checkboxes</option>
+								</select>
+								<p class="description">How the applicant selects their group(s) in the form.</p>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Auto-join groups</th>
+							<td>
+								<?php if (!empty($all_groups)) : ?>
+									<fieldset>
+										<?php foreach ($all_groups as $grp) :
+											$grp_id   = intval($grp['id']);
+											$grp_name = esc_html($grp['name'] ?? '#' . $grp_id);
+										?>
+											<label>
+												<input
+													type="checkbox"
+													name="cinode_recruitment_options[option_auto_subcontractor_group_ids][]"
+													value="<?php echo $grp_id; ?>"
+													<?php checked(in_array($grp_id, $selected_auto_ids, true)); ?>
+												/>
+												<?php echo $grp_name; ?>
+											</label><br>
+										<?php endforeach; ?>
+									</fieldset>
+									<p class="description">Every new subcontractor is silently added to the ticked groups — no selector shown to the applicant. Can be overridden per shortcode: <code>auto_subcontractor_group_ids="12,34"</code>.</p>
+								<?php else : ?>
+									<input
+										type="text"
+										id="cinode_auto_groups"
+										name="cinode_recruitment_options[option_auto_subcontractor_group_ids]"
+										value="<?php echo esc_attr($cinode_opts['option_auto_subcontractor_group_ids'] ?? ''); ?>"
+										class="regular-text"
+										placeholder="e.g. 12,34"
+									/>
+									<p class="description">Comma-separated group IDs every new subcontractor is automatically added to — no selector is shown to the applicant. Can be overridden per shortcode: <code>auto_subcontractor_group_ids="12,34"</code>.</p>
+								<?php endif; ?>
+							</td>
+						</tr>
+					</table>
+				</div>
+			</div>
 
-	<p><b>Default shortcode:</b> [cinode]</p>
-	<p>Insert your shortcode into your page or post.</p>
+			<div class="postbox cinode-card">
+				<div class="postbox-header">
+					<h2 class="hndle">
+						<span class="dashicons dashicons-media-document" aria-hidden="true"></span>
+						CV Upload
+					</h2>
+				</div>
+				<div class="inside">
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">CV required by default</th>
+							<td>
+								<fieldset>
+									<label for="cinode_cv_required">
+										<input
+											type="checkbox"
+											id="cinode_cv_required"
+											name="cinode_recruitment_options[option_cv_required]"
+											value="1"
+											<?php checked(1, $cinode_opts['option_cv_required'] ?? 0); ?>
+										/>
+										Make the file upload field mandatory
+									</label>
+									<p class="description">Override per shortcode: <code>cv_required="1"</code> or <code>cv_required="0"</code>.</p>
+								</fieldset>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">Parse CV on upload</th>
+							<td>
+								<fieldset>
+									<label for="cinode_parse_cv">
+										<input
+											type="checkbox"
+											id="cinode_parse_cv"
+											name="cinode_recruitment_options[option_parse_cv]"
+											value="1"
+											<?php checked(1, $cinode_opts['option_parse_cv'] ?? 0); ?>
+										/>
+										Import the uploaded CV into the subcontractor's Cinode profile (asynchronous)
+									</label>
+									<p class="description">Applies to subcontractors only. Override per shortcode: <code>parse_cv="1"</code> or <code>parse_cv="0"</code>.</p>
+								</fieldset>
+							</td>
+						</tr>
+					</table>
+				</div>
+			</div>
 
-	<p><b>If you want to set custom parametters for your recruitment, add one of the following combination of parameters.</b> </p>
+			<div class="postbox cinode-card">
+				<div class="postbox-header">
+					<h2 class="hndle">
+						<span class="dashicons dashicons-translation" aria-hidden="true"></span>
+						Localisation
+					</h2>
+				</div>
+				<div class="inside">
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">
+								<label for="cinode_lang_id">Default language</label>
+							</th>
+							<td>
+								<?php if (!empty($all_languages)) : ?>
+									<select id="cinode_lang_id" name="cinode_recruitment_options[option_subcontractor_default_language_id]">
+										<?php foreach ($all_languages as $lang) :
+											$lang_id   = intval($lang['languageId'] ?? $lang['id'] ?? 0);
+											$lang_name = esc_html($lang['name'] ?? 'Language ' . $lang_id);
+										?>
+											<option value="<?php echo $lang_id; ?>" <?php selected($selected_lang_id, $lang_id); ?>><?php echo $lang_name; ?></option>
+										<?php endforeach; ?>
+									</select>
+								<?php else : ?>
+									<input
+										type="number"
+										id="cinode_lang_id"
+										min="1"
+										name="cinode_recruitment_options[option_subcontractor_default_language_id]"
+										value="<?php echo esc_attr($selected_lang_id); ?>"
+										class="small-text"
+									/>
+								<?php endif; ?>
+								<p class="description">Language used when creating a subcontractor account in Cinode. Required by the API.</p>
+							</td>
+						</tr>
+					</table>
+				</div>
+			</div>
 
-	<p>[cinode pipelineId = "0" pipelineStageId = "0" recruitmentManagerId = "0" teamId = "0" recruitmentSourceId = "0" campaignCode = "0" currencyId = "1"]</p>
-	<p>If you want to setup pipelineId, you need to set pipelineStageId. <br>
-		Custom labels for the fields can be changed with tags in shortcode. Text must be inside the quotes "".</p>
-	<p> firstname_label="Custom Name" lastname_label="Custom Last Name" email_label="Custom e-mail" phone_label="Custom Phone" message_label="Custom Message" linkedin_label="Custom LinkedIn" location_label="Custom Location Label" attachment_label="Custom Attachment" accept_label="Custom Accept text" privacy_url="https://google.com" privacy_error="Please Accept GDPR" submitbutton_label="Custom Submit application" successful-submit-msg="Thanks for application" unsuccessful-submit-msg="App Not Send" requiredfield_msg="Custom Required Message"</p>
-	<p><b>All available shortcodes are:</b></p>
-	<p>[cinode pipelineId = "0" pipelineStageId = "0" recruitmentManagerId = "0" teamId = "0" recruitmentSourceId = "0" campaignCode = "0" currencyId = "1" firstname_label="Custom Name" lastname_label="Custom Last Name" email_label="Custom e-mail" phone_label="Custom Phone" message_label="Custom Message" linkedin_label="Custom LinkedIn" location_label="Custom Location Label" attachment_label="Custom Attachment" accept_label="Custom Accept text" privacy_url="https://google.com" privacy_error="Please Accept GDPR" submitbutton_label="Custom Submit application" successful-submit-msg="Thanks for application" unsuccessful-submit-msg="App Not Send" requiredfield_msg="Custom Required Message"]</p>
-	<p>If you want to hide Location field use shortcode tag location_label="". If there is no text, field is not shown in the form.</p>	
-	<p></p>
-	<p>If you want to enable field for availableFrom use shortcode tag: availableFrom_label="Available from:"</p>
-	<p></p>
-	<p>If you want enable field for multi pipeline selection add shortcode tags, example: [cinode multiplepipelines="1235:Pipeline 1,1676:Pipeline 2" multiplepipeline_stageid="6003,7783" multiplepipelines_label="Multiple Pipeline select one"]</p>
-	<p>multiplepipelines="pipelineID:Pipeline Label for dropdown"</p>
-	<p>multiplepipeline_stageid="StageID corespondin to PipelineID"</p>
-	<p>multiplepipelines_label="Label on top of the dropdown"</p>
-	<h2>Send confirmation mail to candidate</h2>
+			<?php submit_button('Save Subcontractor Settings', 'primary large', 'submit', true); ?>
+		</div><!-- #tab-subcontractor -->
 
-	<form method="post" action="options.php">
-		<?php settings_fields('cinode_recruitment-settings-mail');
+	</form><!-- #cinode-main-settings-form -->
 
-		$cinode_recruitment_options_sendmail = get_option('cinode_recruitment_options_sendmail');
-		if (!$cinode_recruitment_options_sendmail) {
-			$cinode_recruitment_options_sendmail['option_subject'] = 'Thanks for your application';
-			$cinode_recruitment_options_sendmail['option_message'] = 'Thank you for your application. We will look into your application and get back to you soon.';
-		}
-		?>
-		<p>Set confirmation mail to send to candidate.</p>
-		<table class="form-table">
-			<tr valign="top">
-				<th scope="row">Subject</th>
-				<td><input type="text" name="cinode_recruitment_options_sendmail[option_subject]" style="width:50%;" value="<?php echo esc_attr($cinode_recruitment_options_sendmail['option_subject']); ?>" /></td>
-			</tr>
+	<!-- ============================================================
+	     EMAIL SETTINGS FORM
+	     ============================================================ -->
+	<form method="post" action="options.php" id="cinode-email-settings-form">
+		<?php settings_fields('cinode_recruitment-settings-mail'); ?>
 
-			<tr valign="top">
-				<th scope="row">Message body</th>
-				<td><input type="text" name="cinode_recruitment_options_sendmail[option_message]" style="width:50%;" value="<?php echo $cinode_recruitment_options_sendmail['option_message'] ?>" /></td>
-			</tr>
+		<!-- TAB: Email Confirmation -->
+		<div id="tab-email" class="cinode-tab-content" style="display:none;">
+			<div class="postbox cinode-card">
+				<div class="postbox-header">
+					<h2 class="hndle">
+						<span class="dashicons dashicons-email-alt" aria-hidden="true"></span>
+						Confirmation Email
+					</h2>
+				</div>
+				<div class="inside">
+					<p>This email is sent automatically to the applicant after a successful form submission.</p>
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">
+								<label for="cinode_mail_subject">Subject</label>
+							</th>
+							<td>
+								<input
+									type="text"
+									id="cinode_mail_subject"
+									name="cinode_recruitment_options_sendmail[option_subject]"
+									value="<?php echo esc_attr($mail_opts['option_subject']); ?>"
+									class="large-text"
+								/>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<label for="cinode_mail_message">Message body</label>
+							</th>
+							<td>
+								<textarea
+									id="cinode_mail_message"
+									name="cinode_recruitment_options_sendmail[option_message]"
+									class="large-text"
+									rows="6"
+								><?php echo esc_textarea($mail_opts['option_message']); ?></textarea>
+								<p class="description">Plain-text message sent to the candidate.</p>
+							</td>
+						</tr>
+					</table>
+					<p class="cinode-notice cinode-notice--info">
+						<span class="dashicons dashicons-info-outline" aria-hidden="true"></span>
+						To use a custom SMTP server, install the <a href="https://wordpress.org/plugins/wp-mail-smtp/" target="_blank" rel="noopener noreferrer"><strong>WP Mail SMTP</strong></a> plugin.
+					</p>
+					<?php submit_button('Save Email Settings', 'primary large', 'submit', true); ?>
+				</div>
+			</div>
+		</div><!-- #tab-email -->
 
-		</table>
+	</form><!-- #cinode-email-settings-form -->
 
-		<p class="submit">
-			<input type="submit" class="button-primary" value="Save email message" />
-		</p>
-	</form>
-	<p>If you want to use custom SMTP server to send mail, please install WP mail SMTP plugin. </p>
+	<!-- TAB: Shortcode Reference (no form) -->
+	<div id="tab-shortcode" class="cinode-tab-content" style="display:none;">
 
-	<h2>Spam protection with Google Recaptcha</h2>
-	
-	<p>If you want to protect from spam, Register your Recaptca keys on <a href="https://www.google.com/recaptcha/admin/create" target="_blank">Google Recaptcha</a>. Install plugin <a href="https://wordpress.org/plugins/advanced-nocaptcha-recaptcha/">CAPTCHA 4WP</a> and set your Site Key and Secret.</p>
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-editor-code" aria-hidden="true"></span> Quick Start</h2>
+			</div>
+			<div class="inside">
+				<p>Paste the shortcode into any WordPress page or post. The simplest version:</p>
+				<div class="cinode-code-block">
+					<code id="sc-basic">[cinode]</code>
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-basic" aria-label="Copy shortcode">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					</button>
+				</div>
+			</div>
+		</div>
 
-	
-</div>
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-filter" aria-hidden="true"></span> Core Parameters</h2>
+			</div>
+			<div class="inside">
+				<p>All parameters are optional. If you set <code>pipelineId</code>, you must also set <code>pipelineStageId</code>.</p>
+				<table class="widefat striped cinode-ref-table">
+					<thead>
+						<tr>
+							<th>Parameter</th>
+							<th>Default</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr><td><code>recipient_type</code></td><td><code>"candidate"</code></td><td>Who the form creates: <code>"candidate"</code> or <code>"subcontractor"</code>.</td></tr>
+						<tr><td><code>formtitle</code></td><td><code>""</code></td><td>Heading displayed above the form. Leave empty to show no heading.</td></tr>
+						<tr><td><code>pipelineId</code></td><td><code>0</code></td><td>Cinode pipeline ID to assign the candidate to.</td></tr>
+						<tr><td><code>pipelineStageId</code></td><td><code>0</code></td><td>Stage within the pipeline. <strong>Required</strong> when <code>pipelineId</code> is set.</td></tr>
+						<tr><td><code>recruitmentManagerId</code></td><td><code>0</code></td><td>Cinode user ID of the responsible recruitment manager.</td></tr>
+						<tr><td><code>teamId</code></td><td><code>0</code></td><td>Team ID to associate with the application.</td></tr>
+						<tr><td><code>companyAddressId</code></td><td><code>0</code></td><td>Pre-select a company address. When <code>0</code> the location dropdown fetches all addresses.</td></tr>
+						<tr><td><code>recruitmentSourceId</code></td><td><code>0</code></td><td>Source (channel) ID for tracking where the application came from.</td></tr>
+						<tr><td><code>campaignCode</code></td><td><code>""</code></td><td>Campaign tracking code.</td></tr>
+						<tr><td><code>currencyId</code></td><td><code>1</code></td><td>Currency ID used for any salary-related fields.</td></tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-tag" aria-hidden="true"></span> Field Label Parameters</h2>
+			</div>
+			<div class="inside">
+				<p>Override any field label. Set a parameter to an empty string (<code>""</code>) to hide that field entirely.</p>
+				<table class="widefat striped cinode-ref-table">
+					<thead>
+						<tr>
+							<th>Parameter</th>
+							<th>Hideable?</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr><td><code>firstname_label</code></td><td>&mdash;</td><td>Label for the first name field.</td></tr>
+						<tr><td><code>lastname_label</code></td><td>&mdash;</td><td>Label for the last name field.</td></tr>
+						<tr><td><code>email_label</code></td><td>&mdash;</td><td>Label for the email address field.</td></tr>
+						<tr><td><code>phone_label</code></td><td>&mdash;</td><td>Label for the phone number field.</td></tr>
+						<tr><td><code>message_label</code></td><td>&mdash;</td><td>Label for the message / cover letter field.</td></tr>
+						<tr><td><code>linkedin_label</code></td><td>&mdash;</td><td>Label for the LinkedIn profile URL field.</td></tr>
+						<tr><td><code>location_label</code></td><td>&#10003; set to <code>""</code></td><td>Label for the location field. Leave empty to hide the field.</td></tr>
+						<tr><td><code>attachment_label</code></td><td>&mdash;</td><td>Label for the file upload / CV field.</td></tr>
+						<tr><td><code>accept_label</code></td><td>&mdash;</td><td>Label for the GDPR / privacy acceptance checkbox.</td></tr>
+						<tr><td><code>availableFrom_label</code></td><td>&#10003; omit to hide</td><td>Label for the &ldquo;available from&rdquo; date field. The field is hidden unless this attribute is present.</td></tr>
+						<tr><td><code>submitbutton_label</code></td><td>&mdash;</td><td>Text shown on the submit button.</td></tr>
+						<tr><td><code>groups_label</code></td><td>&mdash;</td><td>Label for the subcontractor group selector (subcontractor mode only).</td></tr>
+						<tr><td><code>gender_label</code></td><td>&mdash;</td><td>Label for the gender field (subcontractor mode only).</td></tr>
+						<tr><td><code>gender_option_male</code></td><td>&mdash;</td><td>Label for the &ldquo;Male&rdquo; gender option.</td></tr>
+						<tr><td><code>gender_option_female</code></td><td>&mdash;</td><td>Label for the &ldquo;Female&rdquo; gender option.</td></tr>
+						<tr><td><code>gender_option_other</code></td><td>&mdash;</td><td>Label for the &ldquo;Other / prefer not to say&rdquo; gender option.</td></tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-warning" aria-hidden="true"></span> Message &amp; Validation Parameters</h2>
+			</div>
+			<div class="inside">
+				<table class="widefat striped cinode-ref-table">
+					<thead>
+						<tr><th>Parameter</th><th>Description</th></tr>
+					</thead>
+					<tbody>
+						<tr><td><code>privacy_url</code></td><td>URL linked from the GDPR/privacy checkbox label (e.g. <code>"https://example.com/privacy"</code>).</td></tr>
+						<tr><td><code>privacy_error</code></td><td>Error message shown when the privacy checkbox is not ticked.</td></tr>
+						<tr><td><code>successful-submit-msg</code></td><td>Message shown to the applicant after a successful submission.</td></tr>
+						<tr><td><code>unsuccessful-submit-msg</code></td><td>Message shown when the submission fails.</td></tr>
+						<tr><td><code>requiredfield_msg</code></td><td>Generic message used for unfilled required fields.</td></tr>
+						<tr><td><code>cv_required</code></td><td>Override the global CV-required setting: <code>"1"</code> = mandatory, <code>"0"</code> = optional.</td></tr>
+						<tr><td><code>parse_cv</code></td><td>Override the global parse-CV setting (subcontractors only): <code>"1"</code> or <code>"0"</code>.</td></tr>
+						<tr><td><code>auto_subcontractor_group_ids</code></td><td>Override the global auto-join group IDs for this shortcode instance.</td></tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-list-view" aria-hidden="true"></span> Multiple Pipelines</h2>
+			</div>
+			<div class="inside">
+				<p>Let applicants choose from several open positions via a dropdown. Map each pipeline to its corresponding stage ID in order.</p>
+				<table class="widefat striped cinode-ref-table">
+					<thead>
+						<tr>
+							<th>Parameter</th>
+							<th>Example value</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><code>multiplepipelines</code></td>
+							<td><code>"1235:Role A,1676:Role B"</code></td>
+							<td>Comma-separated <code>pipelineId:Label</code> pairs shown in the dropdown.</td>
+						</tr>
+						<tr>
+							<td><code>multiplepipeline_stageid</code></td>
+							<td><code>"6003,7783"</code></td>
+							<td>Comma-separated stage IDs, one per pipeline, in the same order.</td>
+						</tr>
+						<tr>
+							<td><code>multiplepipelines_label</code></td>
+							<td><code>"Select a position"</code></td>
+							<td>Label displayed above the pipeline dropdown.</td>
+						</tr>
+					</tbody>
+				</table>
+				<div class="cinode-code-block" style="margin-top:1rem;">
+					<code id="sc-multi">[cinode multiplepipelines="1235:Pipeline 1,1676:Pipeline 2" multiplepipeline_stageid="6003,7783" multiplepipelines_label="Select a position"]</code>
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-multi" aria-label="Copy shortcode">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-media-text" aria-hidden="true"></span> Full Example &mdash; Candidate Mode</h2>
+			</div>
+			<div class="inside">
+				<div class="cinode-code-block">
+					<code id="sc-full">[cinode recipient_type="candidate" formtitle="Apply now" pipelineId="0" pipelineStageId="0" recruitmentManagerId="0" teamId="0" companyAddressId="0" recruitmentSourceId="0" campaignCode="" currencyId="1" firstname_label="First Name" lastname_label="Last Name" email_label="Email" phone_label="Phone" message_label="Cover Letter" linkedin_label="LinkedIn Profile" location_label="Location" availableFrom_label="Available from" attachment_label="Upload CV" accept_label="I accept the Privacy Policy" privacy_url="https://example.com/privacy" privacy_error="Please accept the privacy policy to continue." submitbutton_label="Submit Application" cv_required="0" successful-submit-msg="Thank you! We will be in touch soon." unsuccessful-submit-msg="Something went wrong. Please try again." requiredfield_msg="This field is required."]</code>
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-full" aria-label="Copy shortcode">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle"><span class="dashicons dashicons-businessperson" aria-hidden="true"></span> Full Example &mdash; Subcontractor Mode</h2>
+			</div>
+			<div class="inside">
+				<div class="cinode-code-block">
+					<code id="sc-full-sub">[cinode recipient_type="subcontractor" formtitle="Join our network" firstname_label="First Name" lastname_label="Last Name" email_label="Email" phone_label="Phone" message_label="Cover Letter" linkedin_label="LinkedIn Profile" attachment_label="Upload CV" accept_label="I accept the Privacy Policy" privacy_url="https://example.com/privacy" privacy_error="Please accept the privacy policy to continue." submitbutton_label="Submit" cv_required="1" parse_cv="1" show_subcontractor_groups="1" subcontractor_group_ids="" subcontractor_group_selection="single" groups_label="Apply to group:" auto_subcontractor_group_ids="" gender_label="Gender" gender_option_male="Male" gender_option_female="Female" gender_option_other="Other / prefer not to say" successful-submit-msg="Thank you! We will be in touch soon." unsuccessful-submit-msg="Something went wrong. Please try again." requiredfield_msg="This field is required."]</code>
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-full-sub" aria-label="Copy shortcode">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					</button>
+				</div>
+			</div>
+		</div>
+
+	</div><!-- #tab-shortcode -->
+
+	<!-- TAB: Spam Protection (no form) -->
+	<div id="tab-spam" class="cinode-tab-content" style="display:none;">
+		<div class="postbox cinode-card">
+			<div class="postbox-header">
+				<h2 class="hndle">
+					<span class="dashicons dashicons-shield-alt" aria-hidden="true"></span>
+					Google reCAPTCHA
+				</h2>
+			</div>
+			<div class="inside">
+				<p>Protect your recruitment form from spam submissions using Google reCAPTCHA.</p>
+				<ol class="cinode-step-list">
+					<li>
+						Go to the <a href="https://www.google.com/recaptcha/admin/create" target="_blank" rel="noopener noreferrer">Google reCAPTCHA Admin Console <span class="dashicons dashicons-external" style="font-size:0.85em;vertical-align:middle;" aria-hidden="true"></span></a> and register your site to obtain a <strong>Site Key</strong> and <strong>Secret Key</strong>.
+					</li>
+					<li>
+						Install the <a href="https://wordpress.org/plugins/advanced-nocaptcha-recaptcha/" target="_blank" rel="noopener noreferrer">CAPTCHA 4WP <span class="dashicons dashicons-external" style="font-size:0.85em;vertical-align:middle;" aria-hidden="true"></span></a> plugin from the WordPress plugin directory.
+					</li>
+					<li>In the CAPTCHA 4WP settings, enter your <strong>Site Key</strong> and <strong>Secret Key</strong>.</li>
+					<li>The Cinode Recruitment form will automatically integrate with reCAPTCHA once the plugin is configured.</li>
+				</ol>
+			</div>
+		</div>
+	</div><!-- #tab-spam -->
+
+</div><!-- .cinode-wrap -->
 <?php
 }

--- a/admin/class-cinode-recruitment-admin.php
+++ b/admin/class-cinode-recruitment-admin.php
@@ -74,6 +74,14 @@ class Cinode_Recruitment_Admin {
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/cinode-recruitment-admin.js', array( 'jquery' ), $this->version, false );
 
+		wp_localize_script( $this->plugin_name, 'cinodeRecruitmentAdmin', array(
+			'i18n' => array(
+				'selectAStage'         => __( 'Select a stage', 'cinode-recruitment' ),
+				'selectAPipelineFirst' => __( 'Select a pipeline first', 'cinode-recruitment' ),
+				'copied'               => __( 'Copied!', 'cinode-recruitment' ),
+			),
+		) );
+
 	}
 
 }
@@ -121,6 +129,11 @@ function cinode_recruitment_sanitize_options($input)
 	$raw_selection                                     = $input['option_subcontractor_group_selection'] ?? 'single';
 	$input['option_subcontractor_group_selection']     = in_array($raw_selection, $allowed_selections, true) ? $raw_selection : 'single';
 	$input['option_subcontractor_default_language_id'] = intval($input['option_subcontractor_default_language_id'] ?? 1);
+	$input['option_default_candidate_pipeline_id']     = intval($input['option_default_candidate_pipeline_id'] ?? 0);
+	$input['option_default_candidate_pipeline_stage_id'] = intval($input['option_default_candidate_pipeline_stage_id'] ?? 0);
+	if ($input['option_default_candidate_pipeline_id'] <= 0) {
+		$input['option_default_candidate_pipeline_stage_id'] = 0;
+	}
 	$input['option_cv_required']                       = isset($input['option_cv_required']) ? 1 : 0;
 	$input['option_parse_cv']                          = isset($input['option_parse_cv']) ? 1 : 0;
 	$raw_auto_ids = $input['option_auto_subcontractor_group_ids'] ?? '';
@@ -215,6 +228,44 @@ function cinode_recruitment_admin_fetch_languages()
 	return $languages;
 }
 
+function cinode_recruitment_admin_fetch_candidate_pipelines()
+{
+	$opts      = get_option('cinode_recruitment_options', array());
+	$companyId = $opts['option_companyId'] ?? '';
+	$token     = $opts['option_apiKey'] ?? '';
+
+	if (empty($companyId) || empty($token)) {
+		return array();
+	}
+
+	$cache_key = 'cinode_admin_candidate_pipelines_' . md5((string) $companyId . $token);
+	$cached    = get_transient($cache_key);
+	if ($cached !== false) {
+		return $cached;
+	}
+
+	$url  = 'https://api.cinode.app/v0.1/companies/' . intval($companyId) . '/candidates/pipelines';
+	$args = array(
+		'headers' => array(
+			'Accept'        => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+		'timeout' => 10,
+	);
+
+	$response = wp_remote_get($url, $args);
+	if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+		return array();
+	}
+
+	$pipelines = json_decode(wp_remote_retrieve_body($response), true);
+	$pipelines = is_array($pipelines) ? $pipelines : array();
+
+	set_transient($cache_key, $pipelines, 5 * MINUTE_IN_SECONDS);
+
+	return $pipelines;
+}
+
 function cinode_recruitment_settings_page()
 {
 	$cinode_opts = get_option('cinode_recruitment_options', array());
@@ -223,9 +274,12 @@ function cinode_recruitment_settings_page()
 
 	$all_groups         = $api_valid ? cinode_recruitment_admin_fetch_groups() : array();
 	$all_languages      = $api_valid ? cinode_recruitment_admin_fetch_languages() : array();
+	$all_candidate_pipelines = $api_valid ? cinode_recruitment_admin_fetch_candidate_pipelines() : array();
 	$selected_group_ids = array_filter(array_map('intval', explode(',', $cinode_opts['option_subcontractor_group_ids'] ?? '')));
 	$selected_auto_ids  = array_filter(array_map('intval', explode(',', $cinode_opts['option_auto_subcontractor_group_ids'] ?? '')));
 	$selected_lang_id   = intval($cinode_opts['option_subcontractor_default_language_id'] ?? 1);
+	$selected_candidate_pipeline_id = intval($cinode_opts['option_default_candidate_pipeline_id'] ?? 0);
+	$selected_candidate_stage_id    = intval($cinode_opts['option_default_candidate_pipeline_stage_id'] ?? 0);
 
 	$mail_opts = get_option('cinode_recruitment_options_sendmail', array());
 	if (empty($mail_opts)) {
@@ -240,44 +294,48 @@ function cinode_recruitment_settings_page()
 	<div class="cinode-page-header">
 		<h1 class="cinode-page-title">
 			<span class="dashicons dashicons-groups" aria-hidden="true"></span>
-			Cinode Recruitment
+			<?php esc_html_e( 'Cinode Recruitment', 'cinode-recruitment' ); ?>
 		</h1>
 		<?php if ($api_valid) : ?>
 			<span class="cinode-badge cinode-badge--active">
-				<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span> Connected
+				<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span> <?php esc_html_e( 'Connected', 'cinode-recruitment' ); ?>
 			</span>
 		<?php else : ?>
 			<span class="cinode-badge cinode-badge--inactive">
-				<span class="dashicons dashicons-warning" aria-hidden="true"></span> Not connected — check your API credentials
+				<span class="dashicons dashicons-warning" aria-hidden="true"></span> <?php esc_html_e( 'Not connected — check your API credentials', 'cinode-recruitment' ); ?>
 			</span>
 		<?php endif; ?>
 	</div>
 
-	<nav class="nav-tab-wrapper cinode-nav-tabs" aria-label="Plugin settings sections">
+	<nav class="nav-tab-wrapper cinode-nav-tabs" aria-label="<?php esc_attr_e( 'Plugin settings sections', 'cinode-recruitment' ); ?>">
 		<a href="#tab-api" class="nav-tab nav-tab-active" data-tab="tab-api">
 			<span class="dashicons dashicons-admin-network" aria-hidden="true"></span>
-			<span class="cinode-tab-label">API &amp; Activation</span>
+			<span class="cinode-tab-label"><?php esc_html_e( 'API & Activation', 'cinode-recruitment' ); ?></span>
 		</a>
 		<a href="#tab-subcontractor" class="nav-tab" data-tab="tab-subcontractor">
 			<span class="dashicons dashicons-businessperson" aria-hidden="true"></span>
-			<span class="cinode-tab-label">Subcontractor &amp; CV</span>
+			<span class="cinode-tab-label"><?php esc_html_e( 'CV & Subcontractors', 'cinode-recruitment' ); ?></span>
+		</a>
+		<a href="#tab-candidate" class="nav-tab" data-tab="tab-candidate">
+			<span class="dashicons dashicons-id" aria-hidden="true"></span>
+			<span class="cinode-tab-label"><?php esc_html_e( 'Candidate Defaults', 'cinode-recruitment' ); ?></span>
 		</a>
 		<a href="#tab-email" class="nav-tab" data-tab="tab-email">
 			<span class="dashicons dashicons-email-alt" aria-hidden="true"></span>
-			<span class="cinode-tab-label">Email Confirmation</span>
+			<span class="cinode-tab-label"><?php esc_html_e( 'Email Confirmation', 'cinode-recruitment' ); ?></span>
 		</a>
 		<a href="#tab-shortcode" class="nav-tab" data-tab="tab-shortcode">
 			<span class="dashicons dashicons-editor-code" aria-hidden="true"></span>
-			<span class="cinode-tab-label">Shortcode Reference</span>
+			<span class="cinode-tab-label"><?php esc_html_e( 'Shortcode Reference', 'cinode-recruitment' ); ?></span>
 		</a>
 		<a href="#tab-spam" class="nav-tab" data-tab="tab-spam">
 			<span class="dashicons dashicons-shield" aria-hidden="true"></span>
-			<span class="cinode-tab-label">Spam Protection</span>
+			<span class="cinode-tab-label"><?php esc_html_e( 'Spam Protection', 'cinode-recruitment' ); ?></span>
 		</a>
 	</nav>
 
 	<!-- ============================================================
-	     MAIN SETTINGS FORM — API credentials + Subcontractor & CV
+	     MAIN SETTINGS FORM — API credentials + CV & Subcontractors
 	     Both tab sections share this form so saving from either tab
 	     preserves all settings in cinode_recruitment_options.
 	     ============================================================ -->
@@ -290,15 +348,15 @@ function cinode_recruitment_settings_page()
 				<div class="postbox-header">
 					<h2 class="hndle">
 						<span class="dashicons dashicons-admin-network" aria-hidden="true"></span>
-						API Credentials
+						<?php esc_html_e( 'API Credentials', 'cinode-recruitment' ); ?>
 					</h2>
 				</div>
 				<div class="inside">
-					<p>Enter your Cinode <strong>Company ID</strong> and <strong>API Token</strong> to activate the plugin. You can find these in your Cinode account settings.</p>
+					<p><?php printf( __( 'Enter your Cinode %1$sCompany ID%2$s and %1$sAPI Token%2$s to activate the plugin. You can find these in your Cinode account settings.', 'cinode-recruitment' ), '<strong>', '</strong>' ); ?></p>
 					<table class="form-table" role="presentation">
 						<tr>
 							<th scope="row">
-								<label for="cinode_company_id">Company ID</label>
+								<label for="cinode_company_id"><?php esc_html_e( 'Company ID', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<input
@@ -313,7 +371,7 @@ function cinode_recruitment_settings_page()
 						</tr>
 						<tr>
 							<th scope="row">
-								<label for="cinode_api_key">API Token</label>
+								<label for="cinode_api_key"><?php esc_html_e( 'API Token', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<input
@@ -323,32 +381,32 @@ function cinode_recruitment_settings_page()
 									value="<?php echo esc_attr($apiFieldVal); ?>"
 									class="regular-text"
 									autocomplete="new-password"
-									placeholder="<?php echo $api_valid ? 'Token saved \u2014 enter a new value to replace it' : 'Paste your API token here'; ?>"
+									placeholder="<?php echo esc_attr( $api_valid ? __( 'Token saved — enter a new value to replace it', 'cinode-recruitment' ) : __( 'Paste your API token here', 'cinode-recruitment' ) ); ?>"
 								/>
-								<p class="description"><?php echo $api_valid ? 'Your token is saved. Leave the field showing <code>***</code> to keep it unchanged.' : 'Paste the token from your Cinode account.'; ?></p>
+								<p class="description"><?php echo $api_valid ? wp_kses( __( 'Your token is saved. Leave the field showing <code>***</code> to keep it unchanged.', 'cinode-recruitment' ), array( 'code' => array() ) ) : esc_html__( 'Paste the token from your Cinode account.', 'cinode-recruitment' ); ?></p>
 							</td>
 						</tr>
 					</table>
-					<?php submit_button('Save API Settings', 'primary large', 'submit', true); ?>
+					<?php submit_button( __( 'Save API Settings', 'cinode-recruitment' ), 'primary large', 'submit', true); ?>
 				</div>
 			</div>
 		</div><!-- #tab-api -->
 
-		<!-- TAB: Subcontractor & CV -->
+		<!-- TAB: CV & Subcontractors -->
 		<div id="tab-subcontractor" class="cinode-tab-content" style="display:none;">
 
 			<div class="postbox cinode-card">
 				<div class="postbox-header">
 					<h2 class="hndle">
 						<span class="dashicons dashicons-groups" aria-hidden="true"></span>
-						Subcontractor Groups
+						<?php esc_html_e( 'Subcontractor Groups', 'cinode-recruitment' ); ?>
 					</h2>
 				</div>
 				<div class="inside">
-					<p>Control how the public form presents subcontractor group selection to applicants.</p>
+					<p><?php esc_html_e( 'Control how the public form presents subcontractor group selection to applicants.', 'cinode-recruitment' ); ?></p>
 					<table class="form-table" role="presentation">
 						<tr>
-							<th scope="row">Show group selector</th>
+							<th scope="row"><?php esc_html_e( 'Show group selector', 'cinode-recruitment' ); ?></th>
 							<td>
 								<fieldset>
 									<label for="cinode_show_groups">
@@ -366,7 +424,7 @@ function cinode_recruitment_settings_page()
 						</tr>
 						<tr>
 							<th scope="row">
-								<label for="cinode_group_ids">Groups to display</label>
+								<label for="cinode_group_ids"><?php esc_html_e( 'Groups to display', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<?php if (!empty($all_groups)) : ?>
@@ -384,7 +442,7 @@ function cinode_recruitment_settings_page()
 											<option value="<?php echo $grp_id; ?>" <?php selected(in_array($grp_id, $selected_group_ids, true)); ?>><?php echo $grp_name; ?></option>
 										<?php endforeach; ?>
 									</select>
-									<p class="description">Hold <kbd>Ctrl</kbd> / <kbd>Cmd</kbd> to select multiple groups. Leave all unselected to show every group.</p>
+									<p class="description"><?php printf( esc_html__( 'Hold %1$sCtrl%2$s / %1$sCmd%2$s to select multiple groups. Leave all unselected to show every group.', 'cinode-recruitment' ), '<kbd>', '</kbd>' ); ?></p>
 								<?php else : ?>
 									<input
 										type="text"
@@ -394,24 +452,24 @@ function cinode_recruitment_settings_page()
 										class="regular-text"
 										placeholder="e.g. 12,34,56"
 									/>
-									<p class="description">Comma-separated group IDs. Leave empty to show all groups.</p>
+									<p class="description"><?php esc_html_e( 'Comma-separated group IDs. Leave empty to show all groups.', 'cinode-recruitment' ); ?></p>
 								<?php endif; ?>
 							</td>
 						</tr>
 						<tr>
 							<th scope="row">
-								<label for="cinode_group_selection">Selection mode</label>
+								<label for="cinode_group_selection"><?php esc_html_e( 'Selection mode', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<select id="cinode_group_selection" name="cinode_recruitment_options[option_subcontractor_group_selection]">
-									<option value="single" <?php selected('single', $cinode_opts['option_subcontractor_group_selection'] ?? 'single'); ?>>Single &mdash; dropdown</option>
-									<option value="multiple" <?php selected('multiple', $cinode_opts['option_subcontractor_group_selection'] ?? 'single'); ?>>Multiple &mdash; checkboxes</option>
+									<option value="single" <?php selected('single', $cinode_opts['option_subcontractor_group_selection'] ?? 'single'); ?>><?php esc_html_e( 'Single — dropdown', 'cinode-recruitment' ); ?></option>
+									<option value="multiple" <?php selected('multiple', $cinode_opts['option_subcontractor_group_selection'] ?? 'single'); ?>><?php esc_html_e( 'Multiple — checkboxes', 'cinode-recruitment' ); ?></option>
 								</select>
-								<p class="description">How the applicant selects their group(s) in the form.</p>
+								<p class="description"><?php esc_html_e( 'How the applicant selects their group(s) in the form.', 'cinode-recruitment' ); ?></p>
 							</td>
 						</tr>
 						<tr>
-							<th scope="row">Auto-join groups</th>
+							<th scope="row"><?php esc_html_e( 'Auto-join groups', 'cinode-recruitment' ); ?></th>
 							<td>
 								<?php if (!empty($all_groups)) : ?>
 									<fieldset>
@@ -430,17 +488,17 @@ function cinode_recruitment_settings_page()
 											</label><br>
 										<?php endforeach; ?>
 									</fieldset>
-									<p class="description">Every new subcontractor is silently added to the ticked groups — no selector shown to the applicant. Can be overridden per shortcode: <code>auto_subcontractor_group_ids="12,34"</code>.</p>
-								<?php else : ?>
-									<input
-										type="text"
-										id="cinode_auto_groups"
-										name="cinode_recruitment_options[option_auto_subcontractor_group_ids]"
-										value="<?php echo esc_attr($cinode_opts['option_auto_subcontractor_group_ids'] ?? ''); ?>"
-										class="regular-text"
-										placeholder="e.g. 12,34"
-									/>
-									<p class="description">Comma-separated group IDs every new subcontractor is automatically added to — no selector is shown to the applicant. Can be overridden per shortcode: <code>auto_subcontractor_group_ids="12,34"</code>.</p>
+								<p class="description"><?php echo wp_kses( __( 'Every new subcontractor is silently added to the ticked groups — no selector shown to the applicant. Can be overridden per shortcode: <code>auto_subcontractor_group_ids="12,34"</code>.', 'cinode-recruitment' ), array( 'code' => array() ) ); ?></p>
+							<?php else : ?>
+								<input
+									type="text"
+									id="cinode_auto_groups"
+									name="cinode_recruitment_options[option_auto_subcontractor_group_ids]"
+									value="<?php echo esc_attr($cinode_opts['option_auto_subcontractor_group_ids'] ?? ''); ?>"
+									class="regular-text"
+									placeholder="e.g. 12,34"
+								/>
+								<p class="description"><?php echo wp_kses( __( 'Comma-separated group IDs every new subcontractor is automatically added to — no selector is shown to the applicant. Can be overridden per shortcode: <code>auto_subcontractor_group_ids="12,34"</code>.', 'cinode-recruitment' ), array( 'code' => array() ) ); ?></p>
 								<?php endif; ?>
 							</td>
 						</tr>
@@ -452,13 +510,13 @@ function cinode_recruitment_settings_page()
 				<div class="postbox-header">
 					<h2 class="hndle">
 						<span class="dashicons dashicons-media-document" aria-hidden="true"></span>
-						CV Upload
+						<?php esc_html_e( 'CV Upload', 'cinode-recruitment' ); ?>
 					</h2>
 				</div>
 				<div class="inside">
 					<table class="form-table" role="presentation">
 						<tr>
-							<th scope="row">CV required by default</th>
+							<th scope="row"><?php esc_html_e( 'CV required by default', 'cinode-recruitment' ); ?></th>
 							<td>
 								<fieldset>
 									<label for="cinode_cv_required">
@@ -469,14 +527,14 @@ function cinode_recruitment_settings_page()
 											value="1"
 											<?php checked(1, $cinode_opts['option_cv_required'] ?? 0); ?>
 										/>
-										Make the file upload field mandatory
-									</label>
-									<p class="description">Override per shortcode: <code>cv_required="1"</code> or <code>cv_required="0"</code>.</p>
+									<?php esc_html_e( 'Make the file upload field mandatory', 'cinode-recruitment' ); ?>
+								</label>
+								<p class="description"><?php echo wp_kses( __( 'Override per shortcode: <code>cv_required="1"</code> or <code>cv_required="0"</code>.', 'cinode-recruitment' ), array( 'code' => array() ) ); ?></p>
 								</fieldset>
 							</td>
 						</tr>
 						<tr>
-							<th scope="row">Parse CV on upload</th>
+							<th scope="row"><?php esc_html_e( 'Parse CV on upload', 'cinode-recruitment' ); ?></th>
 							<td>
 								<fieldset>
 									<label for="cinode_parse_cv">
@@ -487,9 +545,9 @@ function cinode_recruitment_settings_page()
 											value="1"
 											<?php checked(1, $cinode_opts['option_parse_cv'] ?? 0); ?>
 										/>
-										Import the uploaded CV into the subcontractor's Cinode profile (asynchronous)
-									</label>
-									<p class="description">Applies to subcontractors only. Override per shortcode: <code>parse_cv="1"</code> or <code>parse_cv="0"</code>.</p>
+									<?php esc_html_e( 'Import the uploaded CV into the applicant\'s Cinode user profile (asynchronous)', 'cinode-recruitment' ); ?>
+								</label>
+								<p class="description"><?php echo wp_kses( __( 'Applies to candidate and subcontractor forms when Cinode returns a company user ID. Override per shortcode: <code>parse_cv="1"</code> or <code>parse_cv="0"</code>.', 'cinode-recruitment' ), array( 'code' => array() ) ); ?></p>
 								</fieldset>
 							</td>
 						</tr>
@@ -501,14 +559,14 @@ function cinode_recruitment_settings_page()
 				<div class="postbox-header">
 					<h2 class="hndle">
 						<span class="dashicons dashicons-translation" aria-hidden="true"></span>
-						Localisation
+						<?php esc_html_e( 'Localisation', 'cinode-recruitment' ); ?>
 					</h2>
 				</div>
 				<div class="inside">
 					<table class="form-table" role="presentation">
 						<tr>
 							<th scope="row">
-								<label for="cinode_lang_id">Default language</label>
+								<label for="cinode_lang_id"><?php esc_html_e( 'Default language', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<?php if (!empty($all_languages)) : ?>
@@ -530,15 +588,103 @@ function cinode_recruitment_settings_page()
 										class="small-text"
 									/>
 								<?php endif; ?>
-								<p class="description">Language used when creating a subcontractor account in Cinode. Required by the API.</p>
+								<p class="description"><?php esc_html_e( 'Language used when creating a subcontractor account in Cinode. Required by the API.', 'cinode-recruitment' ); ?></p>
 							</td>
 						</tr>
 					</table>
 				</div>
 			</div>
 
-			<?php submit_button('Save Subcontractor Settings', 'primary large', 'submit', true); ?>
+			<?php submit_button( __( 'Save CV & Subcontractor Settings', 'cinode-recruitment' ), 'primary large', 'submit', true); ?>
 		</div><!-- #tab-subcontractor -->
+
+		<!-- TAB: Candidate Defaults -->
+		<div id="tab-candidate" class="cinode-tab-content" style="display:none;">
+			<div class="postbox cinode-card">
+				<div class="postbox-header">
+					<h2 class="hndle">
+						<span class="dashicons dashicons-id" aria-hidden="true"></span>
+						<?php esc_html_e( 'Candidate Pipeline Defaults', 'cinode-recruitment' ); ?>
+					</h2>
+				</div>
+				<div class="inside">
+					<p><?php esc_html_e( 'Choose the candidate pipeline and stage used when a candidate shortcode does not include pipeline settings.', 'cinode-recruitment' ); ?></p>
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">
+								<label for="cinode_default_candidate_pipeline_id"><?php esc_html_e( 'Default pipeline', 'cinode-recruitment' ); ?></label>
+							</th>
+							<td>
+								<?php if (!empty($all_candidate_pipelines)) : ?>
+									<select id="cinode_default_candidate_pipeline_id" name="cinode_recruitment_options[option_default_candidate_pipeline_id]">
+										<option value="0" <?php selected(0, $selected_candidate_pipeline_id); ?>><?php esc_html_e( 'No default pipeline', 'cinode-recruitment' ); ?></option>
+										<?php foreach ($all_candidate_pipelines as $pipeline) :
+											$pipeline_id    = intval($pipeline['id'] ?? 0);
+											$pipeline_title = esc_html($pipeline['title'] ?? 'Pipeline ' . $pipeline_id);
+											if ($pipeline_id <= 0) {
+												continue;
+											}
+										?>
+											<option value="<?php echo $pipeline_id; ?>" <?php selected($selected_candidate_pipeline_id, $pipeline_id); ?>><?php echo $pipeline_title; ?></option>
+										<?php endforeach; ?>
+									</select>
+								<?php else : ?>
+									<input
+										type="number"
+										id="cinode_default_candidate_pipeline_id"
+										min="0"
+										name="cinode_recruitment_options[option_default_candidate_pipeline_id]"
+										value="<?php echo esc_attr($selected_candidate_pipeline_id); ?>"
+										class="small-text"
+									/>
+								<?php endif; ?>
+								<p class="description"><?php echo wp_kses( __( 'Omit <code>pipelineId</code>, <code>pipelineStageId</code>, <code>multiplepipelines</code>, and <code>multiplepipeline_stageid</code> in a candidate shortcode to use this default.', 'cinode-recruitment' ), array( 'code' => array() ) ); ?></p>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<label for="cinode_default_candidate_pipeline_stage_id"><?php esc_html_e( 'Default stage', 'cinode-recruitment' ); ?></label>
+							</th>
+							<td>
+								<?php if (!empty($all_candidate_pipelines)) : ?>
+									<select id="cinode_default_candidate_pipeline_stage_id" name="cinode_recruitment_options[option_default_candidate_pipeline_stage_id]">
+										<option value="0" data-pipeline-id="0" <?php selected(0, $selected_candidate_stage_id); ?>><?php esc_html_e( 'Select a pipeline first', 'cinode-recruitment' ); ?></option>
+										<?php foreach ($all_candidate_pipelines as $pipeline) :
+											$pipeline_id    = intval($pipeline['id'] ?? 0);
+											$pipeline_title = esc_html($pipeline['title'] ?? 'Pipeline ' . $pipeline_id);
+											$stages         = is_array($pipeline['stages'] ?? null) ? $pipeline['stages'] : array();
+											if ($pipeline_id <= 0) {
+												continue;
+											}
+											foreach ($stages as $stage) :
+												$stage_id    = intval($stage['id'] ?? 0);
+												$stage_title = esc_html($stage['title'] ?? 'Stage ' . $stage_id);
+												if ($stage_id <= 0) {
+													continue;
+												}
+											?>
+												<option value="<?php echo $stage_id; ?>" data-pipeline-id="<?php echo $pipeline_id; ?>" <?php selected($selected_candidate_stage_id, $stage_id); ?>><?php echo $pipeline_title; ?> &mdash; <?php echo $stage_title; ?></option>
+											<?php endforeach;
+										endforeach; ?>
+									</select>
+								<?php else : ?>
+									<input
+										type="number"
+										id="cinode_default_candidate_pipeline_stage_id"
+										min="0"
+										name="cinode_recruitment_options[option_default_candidate_pipeline_stage_id]"
+										value="<?php echo esc_attr($selected_candidate_stage_id); ?>"
+										class="small-text"
+									/>
+								<?php endif; ?>
+								<p class="description"><?php esc_html_e( 'Select both a pipeline and stage. The default is ignored unless both IDs are saved.', 'cinode-recruitment' ); ?></p>
+							</td>
+						</tr>
+					</table>
+					<?php submit_button( __( 'Save Candidate Defaults', 'cinode-recruitment' ), 'primary large', 'submit', true); ?>
+				</div>
+			</div>
+		</div><!-- #tab-candidate -->
 
 	</form><!-- #cinode-main-settings-form -->
 
@@ -554,15 +700,15 @@ function cinode_recruitment_settings_page()
 				<div class="postbox-header">
 					<h2 class="hndle">
 						<span class="dashicons dashicons-email-alt" aria-hidden="true"></span>
-						Confirmation Email
+						<?php esc_html_e( 'Confirmation Email', 'cinode-recruitment' ); ?>
 					</h2>
 				</div>
 				<div class="inside">
-					<p>This email is sent automatically to the applicant after a successful form submission.</p>
+					<p><?php esc_html_e( 'This email is sent automatically to the applicant after a successful form submission.', 'cinode-recruitment' ); ?></p>
 					<table class="form-table" role="presentation">
 						<tr>
 							<th scope="row">
-								<label for="cinode_mail_subject">Subject</label>
+								<label for="cinode_mail_subject"><?php esc_html_e( 'Subject', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<input
@@ -576,7 +722,7 @@ function cinode_recruitment_settings_page()
 						</tr>
 						<tr>
 							<th scope="row">
-								<label for="cinode_mail_message">Message body</label>
+								<label for="cinode_mail_message"><?php esc_html_e( 'Message body', 'cinode-recruitment' ); ?></label>
 							</th>
 							<td>
 								<textarea
@@ -585,15 +731,15 @@ function cinode_recruitment_settings_page()
 									class="large-text"
 									rows="6"
 								><?php echo esc_textarea($mail_opts['option_message']); ?></textarea>
-								<p class="description">Plain-text message sent to the candidate.</p>
+								<p class="description"><?php esc_html_e( 'Plain-text message sent to the candidate.', 'cinode-recruitment' ); ?></p>
 							</td>
 						</tr>
 					</table>
 					<p class="cinode-notice cinode-notice--info">
 						<span class="dashicons dashicons-info-outline" aria-hidden="true"></span>
-						To use a custom SMTP server, install the <a href="https://wordpress.org/plugins/wp-mail-smtp/" target="_blank" rel="noopener noreferrer"><strong>WP Mail SMTP</strong></a> plugin.
+						<?php printf( wp_kses( __( 'To use a custom SMTP server, install the %s plugin.', 'cinode-recruitment' ), array( 'a' => array( 'href' => array(), 'target' => array(), 'rel' => array() ), 'strong' => array() ) ), '<a href="https://wordpress.org/plugins/wp-mail-smtp/" target="_blank" rel="noopener noreferrer"><strong>WP Mail SMTP</strong></a>' ); ?>
 					</p>
-					<?php submit_button('Save Email Settings', 'primary large', 'submit', true); ?>
+					<?php submit_button( __( 'Save Email Settings', 'cinode-recruitment' ), 'primary large', 'submit', true); ?>
 				</div>
 			</div>
 		</div><!-- #tab-email -->
@@ -605,14 +751,14 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-editor-code" aria-hidden="true"></span> Quick Start</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-editor-code" aria-hidden="true"></span> <?php esc_html_e( 'Quick Start', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
-				<p>Paste the shortcode into any WordPress page or post. The simplest version:</p>
+				<p><?php esc_html_e( 'Paste the shortcode into any WordPress page or post. The simplest version:', 'cinode-recruitment' ); ?></p>
 				<div class="cinode-code-block">
 					<code id="sc-basic">[cinode]</code>
-					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-basic" aria-label="Copy shortcode">
-						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-basic" aria-label="<?php esc_attr_e( 'Copy shortcode', 'cinode-recruitment' ); ?>">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> <?php esc_html_e( 'Copy', 'cinode-recruitment' ); ?>
 					</button>
 				</div>
 			</div>
@@ -620,10 +766,10 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-filter" aria-hidden="true"></span> Core Parameters</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-filter" aria-hidden="true"></span> <?php esc_html_e( 'Core Parameters', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
-				<p>All parameters are optional. If you set <code>pipelineId</code>, you must also set <code>pipelineStageId</code>.</p>
+				<p>All parameters are optional. If you set <code>pipelineId</code>, you must also set <code>pipelineStageId</code>. Omit both to use the configured candidate defaults. Setting either value, including <code>0</code>, makes the shortcode pipeline settings take precedence.</p>
 				<table class="widefat striped cinode-ref-table">
 					<thead>
 						<tr>
@@ -635,8 +781,8 @@ function cinode_recruitment_settings_page()
 					<tbody>
 						<tr><td><code>recipient_type</code></td><td><code>"candidate"</code></td><td>Who the form creates: <code>"candidate"</code> or <code>"subcontractor"</code>.</td></tr>
 						<tr><td><code>formtitle</code></td><td><code>""</code></td><td>Heading displayed above the form. Leave empty to show no heading.</td></tr>
-						<tr><td><code>pipelineId</code></td><td><code>0</code></td><td>Cinode pipeline ID to assign the candidate to.</td></tr>
-						<tr><td><code>pipelineStageId</code></td><td><code>0</code></td><td>Stage within the pipeline. <strong>Required</strong> when <code>pipelineId</code> is set.</td></tr>
+						<tr><td><code>pipelineId</code></td><td>Candidate default or <code>0</code></td><td>Cinode pipeline ID to assign the candidate to. Omit with <code>pipelineStageId</code> to use the admin default.</td></tr>
+						<tr><td><code>pipelineStageId</code></td><td>Candidate default or <code>0</code></td><td>Stage within the pipeline. <strong>Required</strong> when <code>pipelineId</code> is set. Omit with <code>pipelineId</code> to use the admin default.</td></tr>
 						<tr><td><code>recruitmentManagerId</code></td><td><code>0</code></td><td>Cinode user ID of the responsible recruitment manager.</td></tr>
 						<tr><td><code>teamId</code></td><td><code>0</code></td><td>Team ID to associate with the application.</td></tr>
 						<tr><td><code>companyAddressId</code></td><td><code>0</code></td><td>Pre-select a company address. When <code>0</code> the location dropdown fetches all addresses.</td></tr>
@@ -650,7 +796,7 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-tag" aria-hidden="true"></span> Field Label Parameters</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-tag" aria-hidden="true"></span> <?php esc_html_e( 'Field Label Parameters', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
 				<p>Override any field label. Set a parameter to an empty string (<code>""</code>) to hide that field entirely.</p>
@@ -686,7 +832,7 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-warning" aria-hidden="true"></span> Message &amp; Validation Parameters</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-warning" aria-hidden="true"></span> <?php esc_html_e( 'Message & Validation Parameters', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
 				<table class="widefat striped cinode-ref-table">
@@ -700,7 +846,7 @@ function cinode_recruitment_settings_page()
 						<tr><td><code>unsuccessful-submit-msg</code></td><td>Message shown when the submission fails.</td></tr>
 						<tr><td><code>requiredfield_msg</code></td><td>Generic message used for unfilled required fields.</td></tr>
 						<tr><td><code>cv_required</code></td><td>Override the global CV-required setting: <code>"1"</code> = mandatory, <code>"0"</code> = optional.</td></tr>
-						<tr><td><code>parse_cv</code></td><td>Override the global parse-CV setting (subcontractors only): <code>"1"</code> or <code>"0"</code>.</td></tr>
+						<tr><td><code>parse_cv</code></td><td>Override the global parse-CV setting for candidate and subcontractor user profiles: <code>"1"</code> or <code>"0"</code>.</td></tr>
 						<tr><td><code>auto_subcontractor_group_ids</code></td><td>Override the global auto-join group IDs for this shortcode instance.</td></tr>
 					</tbody>
 				</table>
@@ -709,10 +855,10 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-list-view" aria-hidden="true"></span> Multiple Pipelines</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-list-view" aria-hidden="true"></span> <?php esc_html_e( 'Multiple Pipelines', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
-				<p>Let applicants choose from several open positions via a dropdown. Map each pipeline to its corresponding stage ID in order.</p>
+				<p>Let applicants choose from several open positions via a dropdown. Map each pipeline to its corresponding stage ID in order. This shortcode setting takes precedence over the candidate defaults.</p>
 				<table class="widefat striped cinode-ref-table">
 					<thead>
 						<tr>
@@ -741,8 +887,8 @@ function cinode_recruitment_settings_page()
 				</table>
 				<div class="cinode-code-block" style="margin-top:1rem;">
 					<code id="sc-multi">[cinode multiplepipelines="1235:Pipeline 1,1676:Pipeline 2" multiplepipeline_stageid="6003,7783" multiplepipelines_label="Select a position"]</code>
-					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-multi" aria-label="Copy shortcode">
-						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-multi" aria-label="<?php esc_attr_e( 'Copy shortcode', 'cinode-recruitment' ); ?>">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> <?php esc_html_e( 'Copy', 'cinode-recruitment' ); ?>
 					</button>
 				</div>
 			</div>
@@ -750,13 +896,13 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-media-text" aria-hidden="true"></span> Full Example &mdash; Candidate Mode</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-media-text" aria-hidden="true"></span> <?php esc_html_e( 'Full Example — Candidate Mode', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
 				<div class="cinode-code-block">
-					<code id="sc-full">[cinode recipient_type="candidate" formtitle="Apply now" pipelineId="0" pipelineStageId="0" recruitmentManagerId="0" teamId="0" companyAddressId="0" recruitmentSourceId="0" campaignCode="" currencyId="1" firstname_label="First Name" lastname_label="Last Name" email_label="Email" phone_label="Phone" message_label="Cover Letter" linkedin_label="LinkedIn Profile" location_label="Location" availableFrom_label="Available from" attachment_label="Upload CV" accept_label="I accept the Privacy Policy" privacy_url="https://example.com/privacy" privacy_error="Please accept the privacy policy to continue." submitbutton_label="Submit Application" cv_required="0" successful-submit-msg="Thank you! We will be in touch soon." unsuccessful-submit-msg="Something went wrong. Please try again." requiredfield_msg="This field is required."]</code>
-					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-full" aria-label="Copy shortcode">
-						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					<code id="sc-full">[cinode recipient_type="candidate" formtitle="Apply now" pipelineId="0" pipelineStageId="0" recruitmentManagerId="0" teamId="0" companyAddressId="0" recruitmentSourceId="0" campaignCode="" currencyId="1" firstname_label="First Name" lastname_label="Last Name" email_label="Email" phone_label="Phone" message_label="Cover Letter" linkedin_label="LinkedIn Profile" location_label="Location" availableFrom_label="Available from" attachment_label="Upload CV" accept_label="I accept the Privacy Policy" privacy_url="https://example.com/privacy" privacy_error="Please accept the privacy policy to continue." submitbutton_label="Submit Application" cv_required="0" parse_cv="1" successful-submit-msg="Thank you! We will be in touch soon." unsuccessful-submit-msg="Something went wrong. Please try again." requiredfield_msg="This field is required."]</code>
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-full" aria-label="<?php esc_attr_e( 'Copy shortcode', 'cinode-recruitment' ); ?>">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> <?php esc_html_e( 'Copy', 'cinode-recruitment' ); ?>
 					</button>
 				</div>
 			</div>
@@ -764,13 +910,13 @@ function cinode_recruitment_settings_page()
 
 		<div class="postbox cinode-card">
 			<div class="postbox-header">
-				<h2 class="hndle"><span class="dashicons dashicons-businessperson" aria-hidden="true"></span> Full Example &mdash; Subcontractor Mode</h2>
+				<h2 class="hndle"><span class="dashicons dashicons-businessperson" aria-hidden="true"></span> <?php esc_html_e( 'Full Example — Subcontractor Mode', 'cinode-recruitment' ); ?></h2>
 			</div>
 			<div class="inside">
 				<div class="cinode-code-block">
 					<code id="sc-full-sub">[cinode recipient_type="subcontractor" formtitle="Join our network" firstname_label="First Name" lastname_label="Last Name" email_label="Email" phone_label="Phone" message_label="Cover Letter" linkedin_label="LinkedIn Profile" attachment_label="Upload CV" accept_label="I accept the Privacy Policy" privacy_url="https://example.com/privacy" privacy_error="Please accept the privacy policy to continue." submitbutton_label="Submit" cv_required="1" parse_cv="1" show_subcontractor_groups="1" subcontractor_group_ids="" subcontractor_group_selection="single" groups_label="Apply to group:" auto_subcontractor_group_ids="" gender_label="Gender" gender_option_male="Male" gender_option_female="Female" gender_option_other="Other / prefer not to say" successful-submit-msg="Thank you! We will be in touch soon." unsuccessful-submit-msg="Something went wrong. Please try again." requiredfield_msg="This field is required."]</code>
-					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-full-sub" aria-label="Copy shortcode">
-						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> Copy
+					<button type="button" class="button cinode-copy-btn" data-clipboard-target="#sc-full-sub" aria-label="<?php esc_attr_e( 'Copy shortcode', 'cinode-recruitment' ); ?>">
+						<span class="dashicons dashicons-clipboard" aria-hidden="true"></span> <?php esc_html_e( 'Copy', 'cinode-recruitment' ); ?>
 					</button>
 				</div>
 			</div>
@@ -784,20 +930,20 @@ function cinode_recruitment_settings_page()
 			<div class="postbox-header">
 				<h2 class="hndle">
 					<span class="dashicons dashicons-shield-alt" aria-hidden="true"></span>
-					Google reCAPTCHA
+					<?php esc_html_e( 'Google reCAPTCHA', 'cinode-recruitment' ); ?>
 				</h2>
 			</div>
 			<div class="inside">
-				<p>Protect your recruitment form from spam submissions using Google reCAPTCHA.</p>
+				<p><?php esc_html_e( 'Protect your recruitment form from spam submissions using Google reCAPTCHA.', 'cinode-recruitment' ); ?></p>
 				<ol class="cinode-step-list">
 					<li>
-						Go to the <a href="https://www.google.com/recaptcha/admin/create" target="_blank" rel="noopener noreferrer">Google reCAPTCHA Admin Console <span class="dashicons dashicons-external" style="font-size:0.85em;vertical-align:middle;" aria-hidden="true"></span></a> and register your site to obtain a <strong>Site Key</strong> and <strong>Secret Key</strong>.
+						<?php printf( wp_kses( __( 'Go to the %1$sGoogle reCAPTCHA Admin Console %2$s%3$s and register your site to obtain a %4$sSite Key%5$s and %4$sSecret Key%5$s.', 'cinode-recruitment' ), array( 'a' => array( 'href' => array(), 'target' => array(), 'rel' => array() ), 'span' => array( 'class' => array(), 'style' => array(), 'aria-hidden' => array() ), 'strong' => array() ) ), '<a href="https://www.google.com/recaptcha/admin/create" target="_blank" rel="noopener noreferrer">', '<span class="dashicons dashicons-external" style="font-size:0.85em;vertical-align:middle;" aria-hidden="true"></span>', '</a>', '<strong>', '</strong>' ); ?>
 					</li>
 					<li>
-						Install the <a href="https://wordpress.org/plugins/advanced-nocaptcha-recaptcha/" target="_blank" rel="noopener noreferrer">CAPTCHA 4WP <span class="dashicons dashicons-external" style="font-size:0.85em;vertical-align:middle;" aria-hidden="true"></span></a> plugin from the WordPress plugin directory.
+						<?php printf( wp_kses( __( 'Install the %1$sCAPTCHA 4WP %2$s%3$s plugin from the WordPress plugin directory.', 'cinode-recruitment' ), array( 'a' => array( 'href' => array(), 'target' => array(), 'rel' => array() ), 'span' => array( 'class' => array(), 'style' => array(), 'aria-hidden' => array() ) ) ), '<a href="https://wordpress.org/plugins/advanced-nocaptcha-recaptcha/" target="_blank" rel="noopener noreferrer">', '<span class="dashicons dashicons-external" style="font-size:0.85em;vertical-align:middle;" aria-hidden="true"></span>', '</a>' ); ?>
 					</li>
-					<li>In the CAPTCHA 4WP settings, enter your <strong>Site Key</strong> and <strong>Secret Key</strong>.</li>
-					<li>The Cinode Recruitment form will automatically integrate with reCAPTCHA once the plugin is configured.</li>
+					<li><?php printf( wp_kses( __( 'In the CAPTCHA 4WP settings, enter your %1$sSite Key%2$s and %1$sSecret Key%2$s.', 'cinode-recruitment' ), array( 'strong' => array() ) ), '<strong>', '</strong>' ); ?></li>
+					<li><?php esc_html_e( 'The Cinode Recruitment form will automatically integrate with reCAPTCHA once the plugin is configured.', 'cinode-recruitment' ); ?></li>
 				</ol>
 			</div>
 		</div>

--- a/admin/css/cinode-recruitment-admin.css
+++ b/admin/css/cinode-recruitment-admin.css
@@ -6,7 +6,7 @@
    Page wrapper
    ============================================================ */
 .cinode-wrap {
-	max-width: 1100px;
+	max-width: 1200px;
 }
 
 /* ============================================================
@@ -74,19 +74,42 @@
    Tab navigation
    ============================================================ */
 .cinode-nav-tabs {
+	display: flex;
+	align-items: flex-end;
+	gap: 6px;
+	flex-wrap: nowrap;
+	overflow-x: auto;
+	scrollbar-width: thin;
 	margin-top: 16px;
 	border-bottom: 1px solid #c3c4c7;
 }
 
+.cinode-nav-tabs::-webkit-scrollbar {
+	height: 6px;
+}
+
+.cinode-nav-tabs::-webkit-scrollbar-thumb {
+	background: #c3c4c7;
+	border-radius: 3px;
+}
+
+.cinode-nav-tabs::-webkit-scrollbar-track {
+	background: transparent;
+}
+
 .cinode-nav-tabs .nav-tab {
+	float: none !important;
+	flex: 0 0 auto;
 	display: inline-flex !important;
 	align-items: center;
-	gap: 6px;
-	padding: 8px 16px !important;
+	gap: 5px;
+	margin: 0 0 -1px 0 !important;
+	padding: 8px 12px !important;
 	font-size: 0.875rem;
 	cursor: pointer;
 	border-bottom: none;
 	text-decoration: none;
+	white-space: nowrap;
 }
 
 .cinode-nav-tabs .nav-tab:focus {

--- a/admin/css/cinode-recruitment-admin.css
+++ b/admin/css/cinode-recruitment-admin.css
@@ -1,4 +1,317 @@
 /**
- * All of the CSS for your admin-specific functionality should be
- * included in this file.
+ * Cinode Recruitment — Admin Styles
  */
+
+/* ============================================================
+   Page wrapper
+   ============================================================ */
+.cinode-wrap {
+	max-width: 1100px;
+}
+
+/* ============================================================
+   Page header: title + connection badge
+   ============================================================ */
+.cinode-page-header {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	margin: 20px 0 0;
+}
+
+.cinode-page-title {
+	display: flex !important;
+	align-items: center;
+	gap: 8px;
+	font-size: 1.5rem !important;
+	font-weight: 600 !important;
+	color: #1d2327 !important;
+	margin: 0 !important;
+	line-height: 1.3 !important;
+}
+
+.cinode-page-title .dashicons {
+	font-size: 1.6rem;
+	width: 1.6rem;
+	height: 1.6rem;
+	color: #2271b1;
+}
+
+/* ============================================================
+   Connection status badge
+   ============================================================ */
+.cinode-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	padding: 4px 14px;
+	border-radius: 20px;
+	font-size: 0.8125rem;
+	font-weight: 600;
+	line-height: 1.5;
+	white-space: nowrap;
+}
+
+.cinode-badge .dashicons {
+	font-size: 1rem;
+	width: 1rem;
+	height: 1rem;
+}
+
+.cinode-badge--active {
+	background: #d8f5e2;
+	color: #1a6b34;
+	border: 1px solid #9de0b7;
+}
+
+.cinode-badge--inactive {
+	background: #fce8e8;
+	color: #7a1919;
+	border: 1px solid #f5a0a0;
+}
+
+/* ============================================================
+   Tab navigation
+   ============================================================ */
+.cinode-nav-tabs {
+	margin-top: 16px;
+	border-bottom: 1px solid #c3c4c7;
+}
+
+.cinode-nav-tabs .nav-tab {
+	display: inline-flex !important;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 16px !important;
+	font-size: 0.875rem;
+	cursor: pointer;
+	border-bottom: none;
+	text-decoration: none;
+}
+
+.cinode-nav-tabs .nav-tab:focus {
+	outline: 2px solid #2271b1;
+	outline-offset: -2px;
+	box-shadow: none;
+}
+
+.cinode-nav-tabs .nav-tab .dashicons {
+	font-size: 1rem;
+	width: 1rem;
+	height: 1rem;
+	margin: 0;
+}
+
+.cinode-nav-tabs .nav-tab-active {
+	background: #f0f0f1;
+	border-bottom: 1px solid #f0f0f1;
+	margin-bottom: -1px;
+}
+
+/* ============================================================
+   Cards (extend WordPress .postbox)
+   ============================================================ */
+.cinode-card {
+	margin-top: 20px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.cinode-card > .postbox-header {
+	background: #f6f7f7;
+	border-bottom: 1px solid #c3c4c7;
+	border-radius: 4px 4px 0 0;
+	padding: 0 14px;
+	min-height: 48px;
+	display: flex;
+	align-items: center;
+}
+
+.cinode-card > .postbox-header .hndle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 0.9375rem;
+	font-weight: 600;
+	color: #1d2327;
+	padding: 0;
+	margin: 0;
+	cursor: default;
+	border: none;
+	pointer-events: none; /* prevent WP default toggle */
+}
+
+.cinode-card > .postbox-header .hndle .dashicons {
+	color: #2271b1;
+	font-size: 1.1rem;
+	width: 1.1rem;
+	height: 1.1rem;
+}
+
+.cinode-card > .inside {
+	padding: 18px 20px 22px;
+}
+
+.cinode-card > .inside > p:first-child {
+	margin-top: 0;
+	color: #50575e;
+}
+
+/* ============================================================
+   Form table improvements
+   ============================================================ */
+.cinode-card .form-table th {
+	width: 220px;
+	padding-top: 20px;
+	padding-left: 0;
+	vertical-align: top;
+}
+
+.cinode-card .form-table td {
+	vertical-align: top;
+}
+
+.cinode-card .form-table input[type="text"],
+.cinode-card .form-table input[type="password"],
+.cinode-card .form-table input[type="number"],
+.cinode-card .form-table select,
+.cinode-card .form-table textarea {
+	border-radius: 4px;
+}
+
+.cinode-card .form-table .description {
+	margin-top: 6px;
+	color: #646970;
+	font-size: 0.8125rem;
+}
+
+.cinode-card .submit {
+	padding-top: 10px;
+	padding-left: 0;
+}
+
+/* ============================================================
+   Code / shortcode blocks
+   ============================================================ */
+.cinode-code-block {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	background: #f0f2f4;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	padding: 12px 14px;
+}
+
+.cinode-code-block code {
+	flex: 1;
+	font-size: 0.8125rem;
+	line-height: 1.7;
+	word-break: break-all;
+	background: none;
+	padding: 0;
+	color: #1d2327;
+}
+
+.cinode-copy-btn {
+	flex-shrink: 0;
+	display: inline-flex !important;
+	align-items: center;
+	gap: 5px;
+	white-space: nowrap;
+}
+
+.cinode-copy-btn .dashicons {
+	font-size: 1rem;
+	width: 1rem;
+	height: 1rem;
+}
+
+/* ============================================================
+   Shortcode reference tables
+   ============================================================ */
+.cinode-ref-table {
+	border-radius: 4px;
+	overflow: hidden;
+	border: 1px solid #c3c4c7 !important;
+}
+
+.cinode-ref-table thead th {
+	background: #f6f7f7 !important;
+	font-size: 0.8125rem !important;
+	font-weight: 600 !important;
+	color: #1d2327 !important;
+	padding: 10px 14px !important;
+	border-bottom: 1px solid #c3c4c7;
+}
+
+.cinode-ref-table tbody td {
+	font-size: 0.8125rem !important;
+	padding: 9px 14px !important;
+	vertical-align: top;
+}
+
+.cinode-ref-table code {
+	background: #f0f2f4;
+	padding: 2px 6px;
+	border-radius: 3px;
+	font-size: 0.8rem;
+	white-space: nowrap;
+	color: #1d2327;
+}
+
+/* ============================================================
+   Inline notices
+   ============================================================ */
+.cinode-notice {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 10px 14px;
+	border-radius: 4px;
+	margin: 16px 0 0;
+	font-size: 0.875rem;
+	line-height: 1.5;
+}
+
+.cinode-notice .dashicons {
+	flex-shrink: 0;
+	font-size: 1.1rem;
+	width: 1.1rem;
+	height: 1.1rem;
+	margin-top: 2px;
+}
+
+.cinode-notice--info {
+	background: #e7f5ff;
+	border: 1px solid #b8dafe;
+	color: #0c4a6e;
+}
+
+.cinode-notice--info a {
+	color: #0c6fcd;
+}
+
+/* ============================================================
+   Spam protection step list
+   ============================================================ */
+.cinode-step-list {
+	list-style: decimal;
+	margin: 0;
+	padding-left: 1.5em;
+}
+
+.cinode-step-list li {
+	margin-bottom: 10px;
+	line-height: 1.6;
+	color: #1d2327;
+}
+
+.cinode-step-list a {
+	text-decoration: none;
+}
+
+.cinode-step-list a:hover {
+	text-decoration: underline;
+}

--- a/admin/js/cinode-recruitment-admin.js
+++ b/admin/js/cinode-recruitment-admin.js
@@ -1,32 +1,117 @@
 (function( $ ) {
 	'use strict';
 
+	var SESSION_KEY = 'cinode_active_tab';
+
 	/**
-	 * All of the code for your admin-facing JavaScript source
-	 * should reside in this file.
+	 * Show the requested tab and hide all others.
 	 *
-	 * Note: It has been assumed you will write jQuery code here, so the
-	 * $ function reference has been prepared for usage within the scope
-	 * of this function.
-	 *
-	 * This enables you to define handlers, for when the DOM is ready:
-	 *
-	 * $(function() {
-	 *
-	 * });
-	 *
-	 * When the window is loaded:
-	 *
-	 * $( window ).load(function() {
-	 *
-	 * });
-	 *
-	 * ...and/or other possibilities.
-	 *
-	 * Ideally, it is not considered best practise to attach more than a
-	 * single DOM-ready or window-load handler for a particular page.
-	 * Although scripts in the WordPress core, Plugins and Themes may be
-	 * practising this, we should strive to set a better example in our own work.
+	 * @param {string} tabId  Element ID of the tab to activate (without #).
 	 */
+	function activateTab( tabId ) {
+		var $tabs    = $( '.cinode-tab-content' );
+		var $navLink = $( '.cinode-nav-tabs .nav-tab[data-tab="' + tabId + '"]' );
+
+		// Guard: do nothing if the tab does not exist.
+		if ( ! $navLink.length ) {
+			return;
+		}
+
+		$tabs.hide();
+		$( '#' + tabId ).show();
+
+		$( '.cinode-nav-tabs .nav-tab' ).removeClass( 'nav-tab-active' ).removeAttr( 'aria-current' );
+		$navLink.addClass( 'nav-tab-active' ).attr( 'aria-current', 'page' );
+
+		try {
+			sessionStorage.setItem( SESSION_KEY, tabId );
+		} catch ( e ) { /* private browsing — ignore */ }
+	}
+
+	/**
+	 * Determine which tab to show on initial page load.
+	 * Priority: URL hash → sessionStorage → default.
+	 *
+	 * @returns {string} Tab ID.
+	 */
+	function resolveInitialTab() {
+		var hash = window.location.hash.replace( '#', '' );
+
+		if ( hash && $( '.cinode-nav-tabs .nav-tab[data-tab="' + hash + '"]' ).length ) {
+			return hash;
+		}
+
+		try {
+			var stored = sessionStorage.getItem( SESSION_KEY );
+			if ( stored && $( '.cinode-nav-tabs .nav-tab[data-tab="' + stored + '"]' ).length ) {
+				return stored;
+			}
+		} catch ( e ) { /* ignore */ }
+
+		return 'tab-api';
+	}
+
+	$( function() {
+
+		// ---- Tab switching ----------------------------------------
+		$( '.cinode-nav-tabs .nav-tab' ).on( 'click', function( e ) {
+			e.preventDefault();
+			var tab = $( this ).data( 'tab' );
+			activateTab( tab );
+			if ( history.replaceState ) {
+				history.replaceState( null, '', '#' + tab );
+			}
+		} );
+
+		// Restore active tab on load.
+		activateTab( resolveInitialTab() );
+
+
+		// ---- Copy-to-clipboard ------------------------------------
+		$( document ).on( 'click', '.cinode-copy-btn', function() {
+			var $btn    = $( this );
+			var target  = $btn.data( 'clipboard-target' );
+			var text    = $( target ).text().trim();
+			var original = $btn.html();
+
+			function onSuccess() {
+				$btn.html( '<span class="dashicons dashicons-yes" aria-hidden="true"></span> Copied!' );
+				setTimeout( function() {
+					$btn.html( original );
+				}, 2000 );
+			}
+
+			if ( navigator.clipboard && window.isSecureContext ) {
+				navigator.clipboard.writeText( text ).then( onSuccess ).catch( function() {
+					legacyCopy( text, onSuccess );
+				} );
+			} else {
+				legacyCopy( text, onSuccess );
+			}
+		} );
+
+		/**
+		 * Fallback copy for non-secure contexts or older browsers.
+		 *
+		 * @param {string}   text
+		 * @param {Function} callback  Called when copy succeeds.
+		 */
+		function legacyCopy( text, callback ) {
+			var $tmp = $( '<textarea>' )
+				.css( { position: 'fixed', top: 0, left: 0, opacity: 0 } )
+				.val( text )
+				.appendTo( 'body' )
+				.trigger( 'select' );
+
+			try {
+				document.execCommand( 'copy' );
+				if ( typeof callback === 'function' ) { callback(); }
+			} catch ( e ) { /* copy not supported */ }
+
+			$tmp.remove();
+		}
+
+	} );
 
 })( jQuery );
+

--- a/admin/js/cinode-recruitment-admin.js
+++ b/admin/js/cinode-recruitment-admin.js
@@ -66,6 +66,40 @@
 		// Restore active tab on load.
 		activateTab( resolveInitialTab() );
 
+		function syncCandidateDefaultStages() {
+			var $pipeline = $( '#cinode_default_candidate_pipeline_id' );
+			var $stage    = $( '#cinode_default_candidate_pipeline_stage_id' );
+
+			if ( ! $pipeline.length || ! $stage.length || ! $stage.is( 'select' ) ) {
+				return;
+			}
+
+			var selectedPipeline = parseInt( $pipeline.val() || 0, 10 );
+			var selectedStageIsVisible = false;
+
+			$stage.find( 'option' ).each( function() {
+				var $option = $( this );
+				var optionPipeline = parseInt( $option.data( 'pipeline-id' ) || 0, 10 );
+				var shouldShow = optionPipeline === 0 || ( selectedPipeline > 0 && optionPipeline === selectedPipeline );
+
+				$option.prop( 'hidden', ! shouldShow ).prop( 'disabled', ! shouldShow );
+
+				if ( shouldShow && $option.is( ':selected' ) ) {
+					selectedStageIsVisible = true;
+				}
+			} );
+
+			var i18n = ( window.cinodeRecruitmentAdmin && window.cinodeRecruitmentAdmin.i18n ) || {};
+			$stage.find( 'option[value="0"]' ).text( selectedPipeline > 0 ? ( i18n.selectAStage || 'Select a stage' ) : ( i18n.selectAPipelineFirst || 'Select a pipeline first' ) );
+
+			if ( ! selectedStageIsVisible ) {
+				$stage.val( '0' );
+			}
+		}
+
+		$( '#cinode_default_candidate_pipeline_id' ).on( 'change', syncCandidateDefaultStages );
+		syncCandidateDefaultStages();
+
 
 		// ---- Copy-to-clipboard ------------------------------------
 		$( document ).on( 'click', '.cinode-copy-btn', function() {
@@ -75,7 +109,8 @@
 			var original = $btn.html();
 
 			function onSuccess() {
-				$btn.html( '<span class="dashicons dashicons-yes" aria-hidden="true"></span> Copied!' );
+				var i18n = ( window.cinodeRecruitmentAdmin && window.cinodeRecruitmentAdmin.i18n ) || {};
+				$btn.html( '<span class="dashicons dashicons-yes" aria-hidden="true"></span> ' + ( i18n.copied || 'Copied!' ) );
 				setTimeout( function() {
 					$btn.html( original );
 				}, 2000 );

--- a/cinode-recruitment.php
+++ b/cinode-recruitment.php
@@ -264,18 +264,26 @@ function cinodeRecruitmentPost($postData)
 		),
 	);
 
-	$post_result   = wp_remote_post($url, $args);
+	$post_result = wp_remote_post($url, $args);
+
+	if (is_wp_error($post_result)) {
+		error_log('Cinode Recruitment: candidate create failed – ' . $post_result->get_error_message());
+		return cinode_recruitment_rest_status_response(500);
+	}
+
 	$response_code = wp_remote_retrieve_response_code($post_result);
 
 	if ($response_code === 201) {
 		$json_response = json_decode(wp_remote_retrieve_body($post_result), true);
 		$candidateId   = $json_response['id'] ?? null;
-		$companyUserId = cinode_recruitment_get_company_user_id($json_response);
 
-		// Parse CV first (reads from PHP tmp before it is moved by the attachment upload)
+		// Parse CV: first create a user account for the candidate, then import the CV
 		$parse_cv = $postData['parse_cv'] ?? '0';
-		if (($parse_cv === '1' || $parse_cv === true) && !empty($companyUserId) && !empty($postData->get_file_params())) {
-			cinode_recruitment_import_user_profile($postData, $companyUserId, $companyId, $token);
+		if (($parse_cv === '1' || $parse_cv === true) && !empty($candidateId) && !empty($postData->get_file_params())) {
+			$companyUserId = cinode_recruitment_create_candidate_user($postData, $candidateId, $companyId, $token);
+			if (!empty($companyUserId)) {
+				cinode_recruitment_import_user_profile($postData, $companyUserId, $companyId, $token);
+			}
 		}
 
 		if ($candidateId && !empty($postData->get_file_params())) {
@@ -323,7 +331,13 @@ function cinode_recruitment_create_subcontractor($postData, $companyId, $token, 
 		),
 	);
 
-	$post_result   = wp_remote_post($url, $args);
+	$post_result = wp_remote_post($url, $args);
+
+	if (is_wp_error($post_result)) {
+		error_log('Cinode Recruitment: subcontractor create failed – ' . $post_result->get_error_message());
+		return cinode_recruitment_rest_status_response(500);
+	}
+
 	$response_code = wp_remote_retrieve_response_code($post_result);
 
 	if ($response_code === 201) {
@@ -426,9 +440,57 @@ function cinode_recruitment_get_company_user_id($response)
 	return $companyUserId > 0 ? $companyUserId : null;
 }
 
+function cinode_recruitment_create_candidate_user($postData, $candidateId, $companyId, $token)
+{
+	$url = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/candidates/' . intval($candidateId) . '/user';
+
+	$password = wp_generate_password(20, true, true);
+
+	$cinode_recruitment_options = get_option('cinode_recruitment_options');
+	$language_id = intval($cinode_recruitment_options['option_subcontractor_default_language_id'] ?? 0);
+	if ($language_id < 1) {
+		$language_id = 714; // Default to Swedish if not configured
+	}
+
+	$body = array(
+		'firstName'         => sanitize_text_field($postData['firstName']),
+		'lastName'          => sanitize_text_field($postData['lastName']),
+		'email'             => sanitize_email($postData['email']),
+		'password'          => $password,
+		'confirmPassword'   => $password,
+		'languageId'        => $language_id,
+		'profileLanguageId' => $language_id,
+		'createProfile'     => true,
+	);
+
+	$args = array(
+		'body'    => wp_json_encode($body),
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+	);
+
+	$result = wp_remote_post($url, $args);
+
+	if (is_wp_error($result)) {
+		error_log('Cinode Recruitment: candidate user create failed – ' . $result->get_error_message());
+		return null;
+	}
+
+	$response_code = wp_remote_retrieve_response_code($result);
+
+	if ($response_code === 200 || $response_code === 201) {
+		$json_response = json_decode(wp_remote_retrieve_body($result), true);
+		return cinode_recruitment_get_company_user_id($json_response);
+	}
+
+	return null;
+}
+
 function cinode_recruitment_upload_file($request, $candidateId)
 {
-	// Get the file
 	$files = $request->get_file_params();
 
 	if (empty($files['files']['tmp_name']) || !is_uploaded_file($files['files']['tmp_name'])) {
@@ -461,35 +523,14 @@ function cinode_recruitment_upload_file($request, $candidateId)
 
 	$url_attach = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/candidates/' . $candidateId . '/attachments';
 
-	$boundary = cinode_recruitment_boundary();
-
-	$body = '';
-	$body .= '--' . $boundary . "\r\n";
-	$body .= 'Content-Disposition: form-data; name="files"; filename="' . basename($path) . "\"\r\n";
-	$body .= 'Content-Type: ' . $type . "\r\n\r\n";
-	$body .= $file_data . "\r\n";
-	$body .= '--' . $boundary . "\r\n";
-	$body .= 'Content-Disposition: form-data; name="title"' . "\r\n";
-	$body .= 'Content-Type: application/json' . "\r\n\r\n";
-	$body .= $name . "\r\n";
-	$body .= '--' . $boundary . '--' . "\r\n";
-
-
-	$args = array(
-		'body' => $body,
-		'headers' => array(
-			'Accept' => 'text/plain, application/json, text/json, application/xml, text/xml',
-			'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-			'Authorization' => 'Bearer ' . $token,
-		),
-
-	);
-
-	$post_attach_result = wp_remote_post($url_attach, $args);
+	$result = cinode_recruitment_multipart_post($url_attach, $token, array(
+		array('name' => 'files', 'filename' => basename($path), 'type' => $type, 'data' => $file_data),
+		array('name' => 'title', 'data' => $name),
+	));
 
 	wp_delete_file($path);
 
-	return $post_attach_result;
+	return $result;
 }
 
 function cinode_recruitment_upload_subcontractor_file($request, $subcontractorId, $companyId, $token)
@@ -520,29 +561,13 @@ function cinode_recruitment_upload_subcontractor_file($request, $subcontractorId
 		$file_data = '';
 	}
 
-	$url      = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/subcontractors/' . $subcontractorId . '/attachments';
-	$boundary = cinode_recruitment_boundary();
+	$url = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/subcontractors/' . $subcontractorId . '/attachments';
 
-	$body  = '--' . $boundary . "\r\n";
-	$body .= 'Content-Disposition: form-data; name="files"; filename="' . basename($path) . "\"\r\n";
-	$body .= 'Content-Type: ' . $type . "\r\n\r\n";
-	$body .= $file_data . "\r\n";
-	$body .= '--' . $boundary . "\r\n";
-	$body .= 'Content-Disposition: form-data; name="title"' . "\r\n";
-	$body .= 'Content-Type: application/json' . "\r\n\r\n";
-	$body .= $name . "\r\n";
-	$body .= '--' . $boundary . '--' . "\r\n";
+	$result = cinode_recruitment_multipart_post($url, $token, array(
+		array('name' => 'files', 'filename' => basename($path), 'type' => $type, 'data' => $file_data),
+		array('name' => 'title', 'data' => $name),
+	));
 
-	$args = array(
-		'body'    => $body,
-		'headers' => array(
-			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
-			'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
-			'Authorization' => 'Bearer ' . $token,
-		),
-	);
-
-	$result = wp_remote_post($url, $args);
 	wp_delete_file($path);
 
 	return $result;
@@ -570,30 +595,13 @@ function cinode_recruitment_import_user_profile($request, $companyUserId, $compa
 
 	$file_name = $files['files']['name'];
 	$file_type = $file_check['type'];
-	$boundary  = cinode_recruitment_boundary();
 
 	$url = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/users/' . $companyUserId . '/profile/import';
 
-	$body  = '--' . $boundary . "\r\n";
-	$body .= 'Content-Disposition: form-data; name="File"; filename="' . $file_name . "\"\r\n";
-	$body .= 'Content-Type: ' . $file_type . "\r\n\r\n";
-	$body .= $file_data . "\r\n";
-	$body .= '--' . $boundary . "\r\n";
-	$body .= 'Content-Disposition: form-data; name="ImportSkills"' . "\r\n\r\n";
-	$body .= "true\r\n";
-	$body .= '--' . $boundary . '--' . "\r\n";
-
-	$args = array(
-		'body'    => $body,
-		'headers' => array(
-			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
-			'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
-			'Authorization' => 'Bearer ' . $token,
-		),
-		'timeout' => 30,
-	);
-
-	return wp_remote_post($url, $args);
+	return cinode_recruitment_multipart_post($url, $token, array(
+		array('name' => 'File', 'filename' => $file_name, 'type' => $file_type, 'data' => $file_data),
+		array('name' => 'ImportSkills', 'data' => 'true'),
+	), 30);
 }
 
 function cinode_recruitment_import_subcontractor_profile($request, $companyUserId, $companyId, $token)
@@ -683,6 +691,81 @@ function cinode_recruitment_subcontractor_groups($label, $allowed_ids_string, $s
 		}
 		echo '</select><br>';
 	}
+}
+
+/**
+ * Allowed field names for multipart parts.
+ * Reject anything unexpected to prevent header injection via the name param.
+ */
+function cinode_recruitment_allowed_multipart_names()
+{
+	return array('files', 'File', 'title', 'ImportSkills');
+}
+
+/**
+ * Sanitize a filename for safe interpolation into a Content-Disposition header.
+ * Strips path components, quotes, CR/LF, and null bytes.
+ */
+function cinode_recruitment_sanitize_multipart_filename($filename)
+{
+	// Use WP's own sanitizer first (removes path traversal, special chars, etc.)
+	$filename = sanitize_file_name($filename);
+	// Strip characters that can break or inject into MIME headers
+	$filename = str_replace(array('"', "\r", "\n", "\0"), '', $filename);
+	return $filename;
+}
+
+function cinode_recruitment_multipart_post($url, $token, $parts, $timeout = 0)
+{
+	$boundary       = cinode_recruitment_boundary();
+	$body           = '';
+	$allowed_names  = cinode_recruitment_allowed_multipart_names();
+
+	foreach ($parts as $part) {
+		$name = $part['name'] ?? '';
+		if (!in_array($name, $allowed_names, true)) {
+			continue; // skip unknown field names
+		}
+
+		if (!isset($part['data'])) {
+			continue; // every part must carry data
+		}
+
+		$body .= '--' . $boundary . "\r\n";
+
+		if (!empty($part['filename'])) {
+			$safe_filename = cinode_recruitment_sanitize_multipart_filename($part['filename']);
+			$safe_type     = preg_replace('/[\r\n]/', '', $part['type'] ?? 'application/octet-stream');
+			$body .= 'Content-Disposition: form-data; name="' . $name . '"; filename="' . $safe_filename . "\"\r\n";
+			$body .= 'Content-Type: ' . $safe_type . "\r\n";
+		} else {
+			$body .= 'Content-Disposition: form-data; name="' . $name . '"' . "\r\n";
+			if (isset($part['type'])) {
+				$safe_type = preg_replace('/[\r\n]/', '', $part['type']);
+				$body .= 'Content-Type: ' . $safe_type . "\r\n";
+			}
+		}
+
+		$body .= "\r\n";
+		$body .= $part['data'] . "\r\n";
+	}
+
+	$body .= '--' . $boundary . "--\r\n";
+
+	$args = array(
+		'body'    => $body,
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
+			'Authorization' => 'Bearer ' . $token,
+		),
+	);
+
+	if ($timeout > 0) {
+		$args['timeout'] = $timeout;
+	}
+
+	return wp_remote_post($url, $args);
 }
 
 function cinode_recruitment_boundary()

--- a/cinode-recruitment.php
+++ b/cinode-recruitment.php
@@ -13,16 +13,15 @@
  * @package           Cinode_Recruitment
  *
  * @wordpress-plugin
- * Plugin Name:       Cinode recruitment plugin
+ * Plugin Name:       Cinode
  * Plugin URI:        cinode.com
- * Description:       This is Cinode Candidate Recruitment plugin. 
- * Version:           1.5.1
+ * Description:       Integrate your WordPress site with Cinode's Recruitment module. Capture candidate and subcontractor applications directly into your Cinode instance.
+ * Version:           1.6.0
  * Author:            Cinode
  * Author URI:        cinode.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       cinode-recruitment
- 
  */
 
 // If this file is called directly, abort.
@@ -33,7 +32,7 @@ if (!defined('WPINC')) {
 /**
  * Currently plugin version.
  */
-define('CINODE_RECRUITMENT_VERSION', '1.5.1');
+define('CINODE_RECRUITMENT_VERSION', '1.6.0');
 
 /**
  * The code that runs during plugin activation.
@@ -90,8 +89,9 @@ function cinode_recruitment_route()
 		'cinode-recruitment',
 		array(
 			array(
-				'methods' => 'POST',
-				'callback' => 'cinodeRecruitmentPost',
+				'methods'             => 'POST',
+				'callback'            => 'cinodeRecruitmentPost',
+				'permission_callback' => '__return_true',
 				'args' =>  array(
 					'firstName' => array(
 						'required' => true,
@@ -168,6 +168,24 @@ function cinode_recruitment_route()
 						'description' => 'availableFrom',
 					),
 
+					'recipient_type' => array(
+						'type' => 'string',
+						'description' => 'candidate or subcontractor',
+						'default' => 'candidate',
+					),
+					'gender' => array(
+						'type' => 'integer',
+						'description' => 'Gender (0=Other, 1=Male, 2=Female) — subcontractor mode only',
+					),
+					'subcontractorGroupIds' => array(
+						'type' => 'array',
+						'description' => 'Subcontractor group IDs to join',
+					),
+					'parse_cv' => array(
+						'type' => 'string',
+						'description' => 'Whether to import the uploaded CV into the subcontractor profile',
+					),
+
 					'files' => array(),
 				)
 			)
@@ -178,32 +196,60 @@ function cinode_recruitment_route()
 
 function cinodeRecruitmentPost($postData)
 {
-
 	$cinode_recruitment_options = get_option('cinode_recruitment_options');
 	$companyId = $cinode_recruitment_options['option_companyId'];
 	$token = $cinode_recruitment_options['option_apiKey'];
+
+	$recipient_type = sanitize_text_field($postData['recipient_type'] ?? 'candidate');
+
+	if ($recipient_type === 'subcontractor') {
+		return cinode_recruitment_create_subcontractor($postData, $companyId, $token, $cinode_recruitment_options);
+	}
+
+	// --- Candidate flow (original) ---
 	$url = "https://api.cinode.app/v0.1/companies/" . $companyId . "/candidates";
 
 	$body = array(
-		'firstName' => $postData['firstName'],
-		'lastName' => $postData['lastName'],
-		'description' => $postData['description'],
-		'email' => $postData['email'],
-		'phone' => $postData['phone'],
-		'linkedInUrl' => $postData['linkedInUrl'],
-		'state' => $postData['state'],
-		'currencyId' => $postData['currencyId'],
-		'pipelineId' => $postData['pipelineId'],
-		'pipelineStageId' => (int) $postData['pipelineStageId'],
-		'recruitmentManagerId' => $postData['recruitmentManagerId'],
-		'teamId' => $postData['teamId'],
-		'companyAddressId' => $postData['companyAddressId'],
-		'recruitmentSourceId' => $postData['recruitmentSourceId'],
-		'availableFromDate' => $postData['availableFrom'],
-		'campaignCode' => $postData['campaignCode'],
-
+		'firstName'   => sanitize_text_field($postData['firstName']),
+		'lastName'    => sanitize_text_field($postData['lastName']),
+		'description' => sanitize_textarea_field($postData['description']),
+		'email'       => sanitize_email($postData['email']),
+		'phone'       => sanitize_text_field($postData['phone']),
+		'linkedInUrl' => esc_url_raw($postData['linkedInUrl']),
+		'state'       => intval($postData['state']),
+		'currencyId'  => intval($postData['currencyId']),
 	);
 
+	// Only include optional integer fields when actually set; sending 0
+	// causes the Cinode API to reject the request.
+	$optional_int_fields = array(
+		'pipelineId'           => 'pipelineId',
+		'pipelineStageId'      => 'pipelineStageId',
+		'recruitmentManagerId' => 'recruitmentManagerId',
+		'teamId'               => 'teamId',
+		'companyAddressId'     => 'companyAddressId',
+	);
+	foreach ($optional_int_fields as $post_key => $api_key) {
+		$val = intval($postData[$post_key] ?? 0);
+		if ($val > 0) {
+			$body[$api_key] = $val;
+		}
+	}
+
+	$recruitment_source_id = intval($postData['recruitmentSourceId'] ?? 0);
+	if ($recruitment_source_id > 0) {
+		$body['recruitmentSourceId'] = $recruitment_source_id;
+	}
+
+	$available_from = sanitize_text_field($postData['availableFrom'] ?? '');
+	if ($available_from !== '') {
+		$body['availableFromDate'] = $available_from;
+	}
+
+	$campaign_code = sanitize_text_field($postData['campaignCode'] ?? '');
+	if ($campaign_code !== '') {
+		$body['campaignCode'] = $campaign_code;
+	}
 
 	$args = array(
 		'body' => wp_json_encode($body),
@@ -212,52 +258,152 @@ function cinodeRecruitmentPost($postData)
 			'Content-Type' => 'application/json',
 			'Authorization' => 'Bearer ' . $token,
 		),
-
 	);
 
-		$post_result = wp_remote_post($url, $args);
-	
-		$response_code = wp_remote_retrieve_response_code($post_result);
+	$post_result   = wp_remote_post($url, $args);
+	$response_code = wp_remote_retrieve_response_code($post_result);
 
-	if ($response_code != 401) {
+	if ($response_code === 201) {
 		$json_response = json_decode(wp_remote_retrieve_body($post_result), true);
+		$candidateId   = $json_response['id'] ?? null;
 
-		$candidateId = $json_response['id'];
-
-		if (!empty($postData->get_file_params())) {
+		if ($candidateId && !empty($postData->get_file_params())) {
 			cinode_recruitment_upload_file($postData, $candidateId);
 		}
 
-		if ($post_result['response']['code'] == 201) {
-			cinode_recruitment_send_mail($postData['email']);
-		}
+		cinode_recruitment_send_mail(sanitize_email($postData['email']));
 	}
-		
 
-	return $post_result;
+	return new WP_REST_Response(array('status' => $response_code), 200);
+}
+
+function cinode_recruitment_create_subcontractor($postData, $companyId, $token, $options)
+{
+	$url = "https://api.cinode.app/v0.1/companies/" . $companyId . "/subcontractors";
+
+	$language_id = intval($options['option_subcontractor_default_language_id'] ?? 0);
+	if ($language_id < 1) {
+		$language_id = 714; // Default to Swedish if not configured
+	}
+
+	// Generate a secure random password; the subcontractor sets their own via the welcome email.
+	$password = wp_generate_password(20, true, true);
+
+	$body = array(
+		'firstName'       => sanitize_text_field($postData['firstName']),
+		'lastName'        => sanitize_text_field($postData['lastName']),
+		'email'           => sanitize_email($postData['email']),
+		'phone'           => sanitize_text_field($postData['phone'] ?? ''),
+		'gender'          => intval($postData['gender'] ?? 0),
+		'languageId'      => $language_id,
+		'profileLanguageId' => $language_id,
+		'password'        => $password,
+		'passwordConfirm' => $password,
+		'currencyId'      => intval($postData['currencyId'] ?? 1),
+		'createProfile'   => true,
+	);
+
+	if (!empty($postData['companyAddressId'])) {
+		$body['companyAddressId'] = intval($postData['companyAddressId']);
+	}
+
+	$args = array(
+		'body'    => wp_json_encode($body),
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+	);
+
+	$post_result   = wp_remote_post($url, $args);
+	$response_code = wp_remote_retrieve_response_code($post_result);
+
+	if ($response_code === 201) {
+		$json_response  = json_decode(wp_remote_retrieve_body($post_result), true);
+		// id = subcontractor entity ID (used for URL paths like /attachments, /send-welcome-email)
+		// companyUserId = user account ID (used for /users/{id}/profile/import and group membership)
+		$subcontractorId = $json_response['id'];
+		$companyUserId   = $json_response['companyUserId'];
+
+		// Add to requested subcontractor groups
+		$group_ids = $postData['subcontractorGroupIds'] ?? array();
+		if (!is_array($group_ids)) {
+			$group_ids = array_values(array_filter(array_map('intval', explode(',', (string) $group_ids))));
+		}
+		foreach ($group_ids as $group_id) {
+			$group_id = intval($group_id);
+			if ($group_id > 0) {
+				cinode_recruitment_add_to_subcontractor_group($companyId, $token, $companyUserId, $group_id);
+			}
+		}
+
+		// Parse CV first (reads from PHP tmp before it is moved by the attachment upload)
+		$parse_cv = $postData['parse_cv'] ?? '0';
+		if (($parse_cv === '1' || $parse_cv === true) && !empty($companyUserId) && !empty($postData->get_file_params())) {
+			cinode_recruitment_import_subcontractor_profile($postData, $companyUserId, $companyId, $token);
+		}
+
+		// Upload file as attachment
+		if (!empty($postData->get_file_params())) {
+			cinode_recruitment_upload_subcontractor_file($postData, $subcontractorId, $companyId, $token);
+		}
+
+		// Send welcome email so the subcontractor can set their own password
+		$welcome_url = "https://api.cinode.app/v0.1/companies/" . $companyId . "/subcontractors/" . $subcontractorId . "/send-welcome-email";
+		wp_remote_post($welcome_url, array(
+			'headers' => array(
+				'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $token,
+			),
+		));
+
+		// Send confirmation email to applicant
+		cinode_recruitment_send_mail(sanitize_email($postData['email']));
+	}
+
+	return new WP_REST_Response(array('status' => $response_code), 200);
 }
 
 add_action('rest_api_init', 'cinode_recruitment_route');
 
 function cinode_recruitment_upload_file($request, $candidateId)
 {
-	// Get the file 
-	$files   = $request->get_file_params();
-	$target_dir_array =  wp_upload_dir();
-	$target_dir = $target_dir_array['path'] . '/';
-	$target_file = $target_dir . basename($files['files']['name']);
+	// Get the file
+	$files = $request->get_file_params();
+
+	if (empty($files['files']['tmp_name']) || !is_uploaded_file($files['files']['tmp_name'])) {
+		return;
+	}
+
+	$allowed_mimes = array(
+		'pdf'  => 'application/pdf',
+		'doc'  => 'application/msword',
+		'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+		'odt'  => 'application/vnd.oasis.opendocument.text',
+		'rtf'  => 'application/rtf',
+		'txt'  => 'text/plain',
+	);
+	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], $allowed_mimes);
+	if (empty($file_check['ext']) || empty($file_check['type'])) {
+		return;
+	}
+
+	$upload_dir  = wp_upload_dir();
+	$target_dir  = $upload_dir['path'] . '/';
+	$target_file = $target_dir . wp_unique_filename($target_dir, basename($files['files']['name']));
 
 	move_uploaded_file($files['files']['tmp_name'], $target_file);
 
-	$name       = $files['files']['name'];
-	$type       = $files['files']['type'];
-	$path 		= $target_file;
+	$name = $files['files']['name'];
+	$type = $file_check['type'];
+	$path = $target_file;
 
-
-	$file = @fopen($path, 'r');
-	$file_size = filesize($path);
-	$file_data = fread($file, $file_size);
-
+	$file_data = file_get_contents($path);
+	if ($file_data === false) {
+		$file_data = '';
+	}
 
 	$cinode_recruitment_options = get_option('cinode_recruitment_options');
 	$companyId = $cinode_recruitment_options['option_companyId'];
@@ -296,46 +442,240 @@ function cinode_recruitment_upload_file($request, $candidateId)
 	return $post_attach_result;
 }
 
+function cinode_recruitment_upload_subcontractor_file($request, $subcontractorId, $companyId, $token)
+{
+	$files = $request->get_file_params();
+
+	if (empty($files['files']['tmp_name']) || !is_uploaded_file($files['files']['tmp_name'])) {
+		return;
+	}
+
+	$allowed_mimes = array(
+		'pdf'  => 'application/pdf',
+		'doc'  => 'application/msword',
+		'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+		'odt'  => 'application/vnd.oasis.opendocument.text',
+		'rtf'  => 'application/rtf',
+		'txt'  => 'text/plain',
+	);
+	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], $allowed_mimes);
+	if (empty($file_check['ext']) || empty($file_check['type'])) {
+		return;
+	}
+
+	$upload_dir  = wp_upload_dir();
+	$target_dir  = $upload_dir['path'] . '/';
+	$target_file = $target_dir . wp_unique_filename($target_dir, basename($files['files']['name']));
+
+	move_uploaded_file($files['files']['tmp_name'], $target_file);
+
+	$name = $files['files']['name'];
+	$type = $file_check['type'];
+	$path = $target_file;
+
+	$file_data = file_get_contents($path);
+	if ($file_data === false) {
+		$file_data = '';
+	}
+
+	$url      = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/subcontractors/' . $subcontractorId . '/attachments';
+	$boundary = cinode_recruitment_boundary();
+
+	$body  = '--' . $boundary . "\r\n";
+	$body .= 'Content-Disposition: form-data; name="files"; filename="' . basename($path) . "\"\r\n";
+	$body .= 'Content-Type: ' . $type . "\r\n\r\n";
+	$body .= $file_data . "\r\n";
+	$body .= '--' . $boundary . "\r\n";
+	$body .= 'Content-Disposition: form-data; name="title"' . "\r\n";
+	$body .= 'Content-Type: application/json' . "\r\n\r\n";
+	$body .= $name . "\r\n";
+	$body .= '--' . $boundary . '--' . "\r\n";
+
+	$args = array(
+		'body'    => $body,
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
+			'Authorization' => 'Bearer ' . $token,
+		),
+	);
+
+	$result = wp_remote_post($url, $args);
+	wp_delete_file($path);
+
+	return $result;
+}
+
+function cinode_recruitment_import_subcontractor_profile($request, $companyUserId, $companyId, $token)
+{
+	$files    = $request->get_file_params();
+	$tmp_path = $files['files']['tmp_name'] ?? '';
+
+	// The tmp file must still exist (called before the attachment upload moves it)
+	if (empty($tmp_path) || !file_exists($tmp_path)) {
+		return;
+	}
+
+	$file_data = file_get_contents($tmp_path);
+	$file_name = $files['files']['name'];
+	$file_type = $files['files']['type'];
+	$boundary  = cinode_recruitment_boundary();
+
+	$url = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/users/' . $companyUserId . '/profile/import';
+
+	$body  = '--' . $boundary . "\r\n";
+	$body .= 'Content-Disposition: form-data; name="File"; filename="' . $file_name . "\"\r\n";
+	$body .= 'Content-Type: ' . $file_type . "\r\n\r\n";
+	$body .= $file_data . "\r\n";
+	$body .= '--' . $boundary . "\r\n";
+	$body .= 'Content-Disposition: form-data; name="ImportSkills"' . "\r\n\r\n";
+	$body .= "true\r\n";
+	$body .= '--' . $boundary . '--' . "\r\n";
+
+	$args = array(
+		'body'    => $body,
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'multipart/form-data; boundary=' . $boundary,
+			'Authorization' => 'Bearer ' . $token,
+		),
+		'timeout' => 30,
+	);
+
+	return wp_remote_post($url, $args);
+}
+
+function cinode_recruitment_add_to_subcontractor_group($companyId, $token, $companyUserId, $groupId)
+{
+	$url  = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/subcontractors/groups/' . intval($groupId) . '/members';
+	$body = wp_json_encode(array('companyUserSubcontractorId' => intval($companyUserId)));
+
+	$args = array(
+		'body'    => $body,
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+	);
+
+	return wp_remote_post($url, $args);
+}
+
+function cinode_recruitment_subcontractor_groups($label, $allowed_ids_string, $selection_mode)
+{
+	$cinode_recruitment_options = get_option('cinode_recruitment_options');
+	$companyId = $cinode_recruitment_options['option_companyId'];
+	$token     = $cinode_recruitment_options['option_apiKey'];
+	$url       = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/subcontractors/groups';
+
+	$args = array(
+		'headers' => array(
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'application/json',
+			'Authorization' => 'Bearer ' . $token,
+		),
+	);
+
+	$get_result    = wp_remote_get($url, $args);
+	$response_code = wp_remote_retrieve_response_code($get_result);
+
+	if ($response_code !== 200) {
+		return;
+	}
+
+	$groups = json_decode(wp_remote_retrieve_body($get_result), true);
+
+	if (empty($groups) || !is_array($groups)) {
+		return;
+	}
+
+	// Filter to allowed IDs if configured
+	$allowed_ids = array();
+	if (!empty($allowed_ids_string)) {
+		$allowed_ids = array_values(array_filter(array_map('intval', explode(',', $allowed_ids_string))));
+	}
+
+	if (!empty($allowed_ids)) {
+		$groups = array_values(array_filter($groups, function ($group) use ($allowed_ids) {
+			return in_array(intval($group['id']), $allowed_ids, true);
+		}));
+		// Preserve the shortcode-defined order
+		usort($groups, function ($a, $b) use ($allowed_ids) {
+			return array_search(intval($a['id']), $allowed_ids) - array_search(intval($b['id']), $allowed_ids);
+		});
+	}
+
+	if (empty($groups)) {
+		return;
+	}
+
+	echo '<label>' . esc_html($label) . '</label><br>';
+
+	if ($selection_mode === 'multiple') {
+		foreach ($groups as $group) {
+			$id   = intval($group['id']);
+			$name = esc_html($group['name'] ?? '');
+			echo '<label><input type="checkbox" name="subcontractorGroupIds[]" value="' . $id . '"> ' . $name . '</label><br>';
+		}
+	} else {
+		echo '<select name="subcontractorGroupIds[]" id="subcontractorGroupId">';
+		foreach ($groups as $group) {
+			$id   = intval($group['id']);
+			$name = esc_html($group['name'] ?? '');
+			echo '<option value="' . $id . '">' . $name . '</option>';
+		}
+		echo '</select><br>';
+	}
+}
+
 function cinode_recruitment_boundary()
 {
-	$alphabet = "abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ0123456789";
-	$pass = array();
+	$alphabet    = 'abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ0123456789';
 	$alphaLength = strlen($alphabet) - 1;
-	for ($i = 0; $i < 8; $i++) {
-		$n = rand(0, $alphaLength);
-		$pass[] = $alphabet[$n];
+	$pass        = array();
+	try {
+		for ($i = 0; $i < 64; $i++) {
+			$pass[] = $alphabet[random_int(0, $alphaLength)];
+		}
+	} catch (\Throwable $e) {
+		// random_int() throws if the OS entropy source is unavailable.
+		// Fall back to WordPress's own generator which has its own CSPRNG.
+		return substr(wp_generate_password(64, false, false), 0, 64);
 	}
 	return implode($pass);
 }
-
-
-add_action('admin_menu', 'cinode_recruitment_create_menu');
 
 function cinode_recruitment_apiTokenCheck()
 {
 	$cinode_recruitment_options = get_option('cinode_recruitment_options');
 	$companyId = $cinode_recruitment_options['option_companyId'];
-	$token = $cinode_recruitment_options['option_apiKey'];
-	$url = "https://api.cinode.app/v0.1/companies/" . $companyId;
+	$token     = $cinode_recruitment_options['option_apiKey'];
 
+	$cache_key = 'cinode_token_valid_' . md5((string) $companyId . (string) $token);
+	$cached    = get_transient($cache_key);
+	if ($cached !== false) {
+		return (bool) $cached;
+	}
+
+	$url  = 'https://api.cinode.app/v0.1/companies/' . $companyId;
 	$args = array(
 		'headers' => array(
-			'Accept' => 'text/plain, application/json, text/json, application/xml, text/xml',
-			'Content-Type' => 'application/json',
+			'Accept'        => 'text/plain, application/json, text/json, application/xml, text/xml',
+			'Content-Type'  => 'application/json',
 			'Authorization' => 'Bearer ' . $token,
 		),
 	);
 
-	$get_result = wp_remote_get($url, $args);
+	$get_result    = wp_remote_get($url, $args);
+	$json_response = json_decode(wp_remote_retrieve_body($get_result), true);
+	$is_valid      = !empty($json_response);
 
-	$json_response =  json_decode(wp_remote_retrieve_body($get_result), true);
+	set_transient($cache_key, $is_valid ? 1 : 0, 5 * MINUTE_IN_SECONDS);
 
-	if ($json_response) {
-		return true;
-	} else {
-		return false;
-	}
+	return $is_valid;
 }
+
 function cinode_recruitment_send_mail($email)
 {
 	$to = $email;
@@ -350,8 +690,8 @@ function cinode_recruitment_send_mail($email)
 function cinode_recruitment_availableFrom($availableFrom_label)
 {
 ?>
-	<label for="availableFrom"><?php echo $availableFrom_label; ?></label><br>
-	<input type="date" id="availableFrom" />
+	<label for="availableFrom"><?php echo esc_html($availableFrom_label); ?></label><br>
+	<input type="date" id="availableFrom" name="availableFrom" />
 	<br>
 	<?php
 }
@@ -379,22 +719,18 @@ function cinode_recruitment_companyAddresses($location_label)
 	
 		$json_response = json_decode(wp_remote_retrieve_body($get_result), true);
 	
-		if (sizeof($json_response['addresses']) > 0) {
+		$addresses = isset($json_response['addresses']) && is_array($json_response['addresses']) ? $json_response['addresses'] : array();
+
+		if (count($addresses) > 0) {
 
 			?>
-				<label for="companyAddressId"><?php echo $location_label; ?></label><br>
+				<label for="companyAddressId"><?php echo esc_html($location_label); ?></label><br>
 		
 				<select name="companyAddressId" id="companyAddressId">
 		
-					<?php
-		
-					for ($i = 0; $i < count((array)$json_response['addresses']); $i++) {
-		
-					?>
-						<option value="<?php echo $json_response['addresses'][$i]['id']; ?>"><?php echo $json_response['addresses'][$i]['city']; ?></option>
-					<?php
-					}
-					?>
+					<?php foreach ($addresses as $address) : ?>
+						<option value="<?php echo esc_attr($address['id'] ?? ''); ?>"><?php echo esc_html($address['city'] ?? ''); ?></option>
+					<?php endforeach; ?>
 				</select>
 				<br>
 			<?php
@@ -415,9 +751,8 @@ function cinode_recruitment_multiplepipelines($multiplepipelines_label, $pipelin
 	}
 
 
-	echo '<label for="SelectedPipeline">' . $multiplepipelines_label;
-	'</label>';
-	echo '<br><select id="selectedPipelineId">';
+	echo '<label for="SelectedPipeline">' . esc_html($multiplepipelines_label) . '</label>';
+	echo '<br><select id="selectedPipelineId" name="selectedPipelineId">';
 	echo '<option value="">Select</option>';
 
 	$i = 0;
@@ -465,49 +800,101 @@ function cinode_recruitment_shortcode($atts = [])
 		'unsuccessful-submit-msg' => 'Your application is not sent!',
 		'requiredfield_msg' => 'Required field.',
 		'formtitle' => '',
+		// Recipient type
+		'recipient_type' => 'candidate',
+		// Subcontractor groups
+		'show_subcontractor_groups'     => '',
+		'subcontractor_group_ids'       => '',
+		'subcontractor_group_selection' => '',
+		'groups_label'                  => 'Apply to group:',
+		// CV settings
+		'cv_required' => '',
+		'parse_cv'    => '',
+		// Auto-join groups (no selector shown)
+		'auto_subcontractor_group_ids' => '',
+		// Subcontractor-specific field labels
+		'gender_label'       => 'Gender',
+		'gender_option_other'  => 'Other / prefer not to say',
+		'gender_option_male'   => 'Male',
+		'gender_option_female' => 'Female',
 	), $atts, $shortcode = "cinode");
+
+	// Resolve settings: shortcode value overrides admin default.
+	$cinode_options = get_option('cinode_recruitment_options');
+	$cv_required = $args['cv_required'] !== '' ? (bool) $args['cv_required'] : (bool) ($cinode_options['option_cv_required'] ?? 0);
+	$parse_cv    = $args['parse_cv'] !== ''    ? (bool) $args['parse_cv']    : (bool) ($cinode_options['option_parse_cv']     ?? 0);
+	$show_subcontractor_groups   = $args['show_subcontractor_groups'] !== '' ? (bool) $args['show_subcontractor_groups'] : (bool) ($cinode_options['option_show_subcontractor_groups'] ?? 0);
+	$subcontractor_group_ids     = $args['subcontractor_group_ids']   !== '' ? $args['subcontractor_group_ids']   : ($cinode_options['option_subcontractor_group_ids']       ?? '');
+	$subcontractor_group_sel     = $args['subcontractor_group_selection'] !== '' ? $args['subcontractor_group_selection'] : ($cinode_options['option_subcontractor_group_selection'] ?? 'single');
+	$auto_group_ids              = $args['auto_subcontractor_group_ids'] !== '' ? $args['auto_subcontractor_group_ids'] : ($cinode_options['option_auto_subcontractor_group_ids'] ?? '');
+	$is_subcontractor = $args['recipient_type'] === 'subcontractor';
+
+	// Unique counter so multiple shortcodes on the same page each get
+	// distinct element IDs and their own per-form JS configuration.
+	static $cinode_form_uid = 0;
+	++$cinode_form_uid;
+	$uid = $cinode_form_uid;
+
+	// Pre-compute auto-group IDs (used in the data attribute below).
+	$auto_ids_arr = array_values(array_filter(array_map('intval', explode(',', $auto_group_ids))));
 
 	ob_start();
 	?>
 
 	<div class="wrap">
 
-		<h2><?php echo $args['formtitle']; ?></h2>
-		<div role="form" class="cinode-form" lang="en-US" dir="ltr">
-			<form action="#" method="post" id="cinode-form" enctype="multipart/form-data">
-				<script>
-					var pipelineId = <?php echo $args['pipelineid']; ?>;
-					var pipelineStageId = <?php echo $args['pipelinestageid']; ?>;
-					var recruitmentManagerId = <?php echo $args['recruitmentmanagerid']; ?>;
-					var teamId = <?php echo $args['teamid']; ?>;
-					var companyAddressId = <?php echo $args['companyaddressid']; ?>;
-					var recruitmentSourceId = <?php echo $args['recruitmentsourceid']; ?>;
-					var campaignCode = "<?php echo $args['campaigncode']; ?>";
-					var currencyId = <?php echo $args['currencyid']; ?>;
-				</script>
+		<h2><?php echo esc_html($args['formtitle']); ?></h2>
+		<div role="form" class="cinode-form"
+			data-pipeline-id="<?php echo intval($args['pipelineid']); ?>"
+			data-pipeline-stage-id="<?php echo intval($args['pipelinestageid']); ?>"
+			data-recruitment-manager-id="<?php echo intval($args['recruitmentmanagerid']); ?>"
+			data-team-id="<?php echo intval($args['teamid']); ?>"
+			data-company-address-id="<?php echo intval($args['companyaddressid']); ?>"
+			data-recruitment-source-id="<?php echo intval($args['recruitmentsourceid']); ?>"
+			data-campaign-code="<?php echo esc_attr($args['campaigncode']); ?>"
+			data-currency-id="<?php echo intval($args['currencyid']); ?>"
+			data-recipient-type="<?php echo esc_attr($args['recipient_type']); ?>"
+			data-cv-required="<?php echo $cv_required ? 'true' : 'false'; ?>"
+			data-parse-cv="<?php echo $parse_cv ? 'true' : 'false'; ?>"
+			data-auto-subcontractor-group-ids="<?php echo esc_attr(wp_json_encode($auto_ids_arr)); ?>"
+			lang="en-US" dir="ltr">
+			<form action="#" method="post" id="cinode-form-<?php echo esc_attr($uid); ?>" enctype="multipart/form-data">
+				<input type="hidden" name="recipient_type" value="<?php echo esc_attr($args['recipient_type']); ?>">
+				<input type="hidden" name="parse_cv" value="<?php echo $parse_cv ? '1' : '0'; ?>">
 				<div>
-					<label><?php echo $args['firstname_label']; ?> *<br>
-						<span class=""><input type="text" id="first_name-input" name="first_name" value="" size="100%" class="text " aria-required="true" aria-invalid="false" placeholder=" "></span>
-						<span role="alert" id="first_name-required" class="alert-required" style="display: none"><?php echo $args['requiredfield_msg']; ?></span>
+					<label><?php echo esc_html($args['firstname_label']); ?> *<br>
+						<span class=""><input type="text" id="first_name-input-<?php echo esc_attr($uid); ?>" name="first_name" value="" size="100%" class="text " aria-required="true" aria-invalid="false" placeholder=" "></span>
+						<span role="alert" id="first_name-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-firstname-required" style="display: none"><?php echo esc_html($args['requiredfield_msg']); ?></span>
 					</label><br>
-					<label><?php echo $args['lastname_label']; ?> *<br>
-						<span class=""><input type="text" id="last_name-input" name="last_name" value="" size="100%" class=" text " aria-required="true" aria-invalid="false" placeholder=" ">
-							<span role="alert" id="last_name-required" class="alert-required" style="display: none"><?php echo $args['requiredfield_msg']; ?></span></span> </label><br>
-					<label><?php echo $args['email_label']; ?> *<br>
-						<span class=""><input type="email" id="email-input" name="email" value="" size="100%" class=" text " aria-required="true" aria-invalid="false" placeholder=" ">
-							<span role="alert" id="email-required" class="alert-required" style="display: none"><?php echo $args['requiredfield_msg']; ?></span></span>
+					<label><?php echo esc_html($args['lastname_label']); ?> *<br>
+						<span class=""><input type="text" id="last_name-input-<?php echo esc_attr($uid); ?>" name="last_name" value="" size="100%" class=" text " aria-required="true" aria-invalid="false" placeholder=" ">
+							<span role="alert" id="last_name-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-lastname-required" style="display: none"><?php echo esc_html($args['requiredfield_msg']); ?></span></span> </label><br>
+					<label><?php echo esc_html($args['email_label']); ?> *<br>
+						<span class=""><input type="email" id="email-input-<?php echo esc_attr($uid); ?>" name="email" value="" size="100%" class=" text " aria-required="true" aria-invalid="false" placeholder=" ">
+							<span role="alert" id="email-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-email-required" style="display: none"><?php echo esc_html($args['requiredfield_msg']); ?></span></span>
 					</label><br>
-					<label><?php echo $args['phone_label']; ?><br>
-						<span class=""><input type="text" id="phone-input" placeholder=" " name="phone" value="" size="100%" class=" text" aria-required="false" aria-invalid="false"></span>
-						<span role="alert" id="phone-required" class="alert-required" style="display: none"><?php echo $args['requiredfield_msg']; ?></span>
+					<label><?php echo esc_html($args['phone_label']); ?><br>
+						<span class=""><input type="text" id="phone-input-<?php echo esc_attr($uid); ?>" placeholder=" " name="phone" value="" size="100%" class=" text" aria-required="false" aria-invalid="false"></span>
+						<span role="alert" id="phone-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-phone-required" style="display: none"><?php echo esc_html($args['requiredfield_msg']); ?></span>
 						</span>
 					</label><br>
-					<label><?php echo $args['message_label']; ?> <br>
-						<textarea class="autosize" cols="20" id="description-input" name="Description" size="100%" rows="2" style="overflow-wrap: break-word; resize: vertical; height: 150px;"></textarea>
+					<label><?php echo esc_html($args['message_label']); ?> <br>
+						<textarea class="autosize" cols="20" id="description-input-<?php echo esc_attr($uid); ?>" name="Description" size="100%" rows="2" style="overflow-wrap: break-word; resize: vertical; height: 150px;"></textarea>
 					</label><br>
-					<label><?php echo $args['linkedin_label']; ?><br>
-						<input data-val="true" size="100%" id="LinkedInUrl" name="LinkedInUrl" type="text" value="">
+					<label><?php echo esc_html($args['linkedin_label']); ?><br>
+						<input data-val="true" size="100%" id="LinkedInUrl-<?php echo esc_attr($uid); ?>" name="LinkedInUrl" type="text" value="">
 					</label> <br>
+
+					<?php if ($is_subcontractor) : ?>
+					<label><?php echo esc_html($args['gender_label']); ?> *<br>
+						<select id="gender-input-<?php echo esc_attr($uid); ?>" name="gender">
+							<option value="0"><?php echo esc_html($args['gender_option_other']); ?></option>
+							<option value="1"><?php echo esc_html($args['gender_option_male']); ?></option>
+							<option value="2"><?php echo esc_html($args['gender_option_female']); ?></option>
+						</select>
+						<span role="alert" id="gender-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-gender-required" style="display:none"><?php echo esc_html($args['requiredfield_msg']); ?></span>
+					</label><br>
+					<?php endif; ?>
 
 					<?php
 					$location_label = $args['location_label'];
@@ -520,34 +907,44 @@ function cinode_recruitment_shortcode($atts = [])
 						cinode_recruitment_availableFrom($availableFrom_label);
 					}
 
-					$multiplepipelines_label = $args['multiplepipelines_label'];
-					$pipelines_string = $args['multiplepipelines'];
-					$pipelines_stageId = $args['multiplepipeline_stageid'];
-					
-					if (($pipelines_string)) {
-						cinode_recruitment_multiplepipelines($multiplepipelines_label, $pipelines_string, $pipelines_stageId);
+					// Subcontractors cannot be placed into pipelines; only candidates can.
+					if (!$is_subcontractor) {
+						$multiplepipelines_label = $args['multiplepipelines_label'];
+						$pipelines_string = $args['multiplepipelines'];
+						$pipelines_stageId = $args['multiplepipeline_stageid'];
+
+						if ($pipelines_string) {
+							cinode_recruitment_multiplepipelines($multiplepipelines_label, $pipelines_string, $pipelines_stageId);
+						}
+					}
+
+					if ($is_subcontractor && $show_subcontractor_groups) {
+						cinode_recruitment_subcontractor_groups($args['groups_label'], $subcontractor_group_ids, $subcontractor_group_sel);
 					}
 
 					?>
 					<br>
-					<div for="file-upload" class="custom-file-upload ">
-							<?php echo $args['attachment_label']; ?>
-						<input id="file-upload" class="file-upload" type="file" />
-						<label class="file-name"></label>	
+					<div for="file-upload-<?php echo esc_attr($uid); ?>" class="custom-file-upload ">
+						<?php echo esc_html($args['attachment_label']); ?><?php if ($cv_required) echo ' *'; ?>
+						<input id="file-upload-<?php echo esc_attr($uid); ?>" class="file-upload" type="file" />
+						<label class="file-name"></label>
+						<?php if ($cv_required) : ?>
+						<span role="alert" id="file-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-file-required" style="display:none"><?php echo esc_html($args['requiredfield_msg']); ?></span>
+						<?php endif; ?>
 					</div>
 					<br>
-					<input type="checkbox" name="terms" id="terms">
-					<a href="<?php echo $args['privacy_url']; ?>" rel="noopener noreferrer" target="_blank">
-						<?php echo $args['accept_label']; ?></a>
+					<input type="checkbox" name="terms" id="terms-<?php echo esc_attr($uid); ?>">
+					<a href="<?php echo esc_url($args['privacy_url']); ?>" rel="noopener noreferrer" target="_blank">
+						<?php echo esc_html($args['accept_label']); ?></a>
 					<br>
-					<span id="terms-validate" style="display:none; color:red;"> <?php echo $args['privacy_error']; ?></span>
-					<input type="hidden" name="g-recaptcha-response" value="" id="g-recaptcha-response">
+					<span id="terms-validate-<?php echo esc_attr($uid); ?>" class="cinode-terms-validate" style="display:none; color:red;"> <?php echo esc_html($args['privacy_error']); ?></span>
+					<input type="hidden" name="g-recaptcha-response" value="" id="g-recaptcha-response-<?php echo esc_attr($uid); ?>">
 					<?php do_action('c4wp_captcha_form_field'); ?>
 				</div>
 				<div class="row">
 					<div>
 						<br>
-						<p><input type="submit" id="submit" value="<?php echo $args['submitbutton_label']; ?>"></p>
+						<p><input type="submit" id="submit-<?php echo esc_attr($uid); ?>" value="<?php echo esc_attr($args['submitbutton_label']); ?>"></p>
 					</div>
 				</div>
 				<div class="spinner" style="display: none;">
@@ -556,11 +953,11 @@ function cinode_recruitment_shortcode($atts = [])
 					<div class="bounce3"></div>
 				</div>
 
-				<div class="alert" id="successful-submit-msg" style="display:none; background: green; color: white; text-align: center;">
-					<?php echo $args['successful-submit-msg']; ?>
+				<div class="alert cinode-success-msg" id="successful-submit-msg-<?php echo esc_attr($uid); ?>" style="display:none; background: green; color: white; text-align: center;">
+					<?php echo esc_html($args['successful-submit-msg']); ?>
 				</div>
-				<div class="alert" id="unsuccessful-submit-msg" style="display: none; background: red; color: white; text-align: center;">
-					<?php echo $args['unsuccessful-submit-msg']; ?>
+				<div class="alert cinode-error-msg" id="unsuccessful-submit-msg-<?php echo esc_attr($uid); ?>" style="display: none; background: red; color: white; text-align: center;">
+					<?php echo esc_html($args['unsuccessful-submit-msg']); ?>
 				</div>
 			</form>
 		</div>

--- a/cinode-recruitment.php
+++ b/cinode-recruitment.php
@@ -459,7 +459,6 @@ function cinode_recruitment_create_candidate_user($postData, $candidateId, $comp
 		'password'          => $password,
 		'confirmPassword'   => $password,
 		'languageId'        => $language_id,
-		'profileLanguageId' => $language_id,
 		'createProfile'     => true,
 	);
 
@@ -486,6 +485,7 @@ function cinode_recruitment_create_candidate_user($postData, $candidateId, $comp
 		return cinode_recruitment_get_company_user_id($json_response);
 	}
 
+	error_log('Cinode Recruitment: candidate user create returned HTTP ' . $response_code . ' – ' . wp_remote_retrieve_body($result));
 	return null;
 }
 
@@ -598,10 +598,21 @@ function cinode_recruitment_import_user_profile($request, $companyUserId, $compa
 
 	$url = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/users/' . $companyUserId . '/profile/import';
 
-	return cinode_recruitment_multipart_post($url, $token, array(
+	$result = cinode_recruitment_multipart_post($url, $token, array(
 		array('name' => 'File', 'filename' => $file_name, 'type' => $file_type, 'data' => $file_data),
 		array('name' => 'ImportSkills', 'data' => 'true'),
 	), 30);
+
+	if (is_wp_error($result)) {
+		error_log('Cinode Recruitment: profile import failed – ' . $result->get_error_message());
+	} else {
+		$response_code = wp_remote_retrieve_response_code($result);
+		if ($response_code < 200 || $response_code >= 300) {
+			error_log('Cinode Recruitment: profile import returned HTTP ' . $response_code . ' – ' . wp_remote_retrieve_body($result));
+		}
+	}
+
+	return $result;
 }
 
 function cinode_recruitment_import_subcontractor_profile($request, $companyUserId, $companyId, $token)

--- a/cinode-recruitment.php
+++ b/cinode-recruitment.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Cinode
  * Plugin URI:        cinode.com
  * Description:       Integrate your WordPress site with Cinode's Recruitment module. Capture candidate and subcontractor applications directly into your Cinode instance.
- * Version:           1.6.0
+ * Version:           1.6.3
  * Author:            Cinode
  * Author URI:        cinode.com
  * License:           GPL-2.0+
@@ -32,7 +32,7 @@ if (!defined('WPINC')) {
 /**
  * Currently plugin version.
  */
-define('CINODE_RECRUITMENT_VERSION', '1.6.0');
+define('CINODE_RECRUITMENT_VERSION', '1.6.3');
 
 /**
  * The code that runs during plugin activation.
@@ -183,7 +183,7 @@ function cinode_recruitment_route()
 					),
 					'parse_cv' => array(
 						'type' => 'string',
-						'description' => 'Whether to import the uploaded CV into the subcontractor profile',
+						'description' => 'Whether to import the uploaded CV into the applicant\'s Cinode user profile',
 					),
 
 					'files' => array(),
@@ -199,6 +199,10 @@ function cinodeRecruitmentPost($postData)
 	$cinode_recruitment_options = get_option('cinode_recruitment_options');
 	$companyId = $cinode_recruitment_options['option_companyId'];
 	$token = $cinode_recruitment_options['option_apiKey'];
+
+	if (!cinode_recruitment_uploaded_cv_is_valid($postData)) {
+		return cinode_recruitment_rest_status_response(415);
+	}
 
 	$recipient_type = sanitize_text_field($postData['recipient_type'] ?? 'candidate');
 
@@ -266,6 +270,13 @@ function cinodeRecruitmentPost($postData)
 	if ($response_code === 201) {
 		$json_response = json_decode(wp_remote_retrieve_body($post_result), true);
 		$candidateId   = $json_response['id'] ?? null;
+		$companyUserId = cinode_recruitment_get_company_user_id($json_response);
+
+		// Parse CV first (reads from PHP tmp before it is moved by the attachment upload)
+		$parse_cv = $postData['parse_cv'] ?? '0';
+		if (($parse_cv === '1' || $parse_cv === true) && !empty($companyUserId) && !empty($postData->get_file_params())) {
+			cinode_recruitment_import_user_profile($postData, $companyUserId, $companyId, $token);
+		}
 
 		if ($candidateId && !empty($postData->get_file_params())) {
 			cinode_recruitment_upload_file($postData, $candidateId);
@@ -274,7 +285,7 @@ function cinodeRecruitmentPost($postData)
 		cinode_recruitment_send_mail(sanitize_email($postData['email']));
 	}
 
-	return new WP_REST_Response(array('status' => $response_code), 200);
+	return cinode_recruitment_rest_status_response($response_code);
 }
 
 function cinode_recruitment_create_subcontractor($postData, $companyId, $token, $options)
@@ -303,10 +314,6 @@ function cinode_recruitment_create_subcontractor($postData, $companyId, $token, 
 		'createProfile'   => true,
 	);
 
-	if (!empty($postData['companyAddressId'])) {
-		$body['companyAddressId'] = intval($postData['companyAddressId']);
-	}
-
 	$args = array(
 		'body'    => wp_json_encode($body),
 		'headers' => array(
@@ -324,7 +331,7 @@ function cinode_recruitment_create_subcontractor($postData, $companyId, $token, 
 		// id = subcontractor entity ID (used for URL paths like /attachments, /send-welcome-email)
 		// companyUserId = user account ID (used for /users/{id}/profile/import and group membership)
 		$subcontractorId = $json_response['id'];
-		$companyUserId   = $json_response['companyUserId'];
+		$companyUserId   = cinode_recruitment_get_company_user_id($json_response);
 
 		// Add to requested subcontractor groups
 		$group_ids = $postData['subcontractorGroupIds'] ?? array();
@@ -341,7 +348,7 @@ function cinode_recruitment_create_subcontractor($postData, $companyId, $token, 
 		// Parse CV first (reads from PHP tmp before it is moved by the attachment upload)
 		$parse_cv = $postData['parse_cv'] ?? '0';
 		if (($parse_cv === '1' || $parse_cv === true) && !empty($companyUserId) && !empty($postData->get_file_params())) {
-			cinode_recruitment_import_subcontractor_profile($postData, $companyUserId, $companyId, $token);
+			cinode_recruitment_import_user_profile($postData, $companyUserId, $companyId, $token);
 		}
 
 		// Upload file as attachment
@@ -363,10 +370,61 @@ function cinode_recruitment_create_subcontractor($postData, $companyId, $token, 
 		cinode_recruitment_send_mail(sanitize_email($postData['email']));
 	}
 
-	return new WP_REST_Response(array('status' => $response_code), 200);
+	return cinode_recruitment_rest_status_response($response_code);
+}
+
+function cinode_recruitment_rest_status_response($status)
+{
+	return new WP_REST_Response(array('status' => $status), $status);
 }
 
 add_action('rest_api_init', 'cinode_recruitment_route');
+
+function cinode_recruitment_allowed_cv_mimes()
+{
+	return array(
+		'pdf'  => 'application/pdf',
+		'doc'  => 'application/msword',
+		'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	);
+}
+
+function cinode_recruitment_uploaded_cv_is_valid($request)
+{
+	$files = $request->get_file_params();
+
+	if (empty($files['files'])) {
+		return true;
+	}
+
+	if (empty($files['files']['tmp_name']) || empty($files['files']['name']) || !is_uploaded_file($files['files']['tmp_name'])) {
+		return false;
+	}
+
+	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], cinode_recruitment_allowed_cv_mimes());
+
+	return !empty($file_check['ext']) && !empty($file_check['type']);
+}
+
+function cinode_recruitment_get_company_user_id($response)
+{
+	if (!is_array($response)) {
+		return null;
+	}
+
+	$companyUserId = $response['companyUserId'] ?? null;
+
+	if ($companyUserId === null) {
+		$companyUser = $response['companyUser'] ?? null;
+		if (is_array($companyUser)) {
+			$companyUserId = $companyUser['companyUserId'] ?? $companyUser['id'] ?? null;
+		}
+	}
+
+	$companyUserId = intval($companyUserId);
+
+	return $companyUserId > 0 ? $companyUserId : null;
+}
 
 function cinode_recruitment_upload_file($request, $candidateId)
 {
@@ -377,15 +435,7 @@ function cinode_recruitment_upload_file($request, $candidateId)
 		return;
 	}
 
-	$allowed_mimes = array(
-		'pdf'  => 'application/pdf',
-		'doc'  => 'application/msword',
-		'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		'odt'  => 'application/vnd.oasis.opendocument.text',
-		'rtf'  => 'application/rtf',
-		'txt'  => 'text/plain',
-	);
-	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], $allowed_mimes);
+	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], cinode_recruitment_allowed_cv_mimes());
 	if (empty($file_check['ext']) || empty($file_check['type'])) {
 		return;
 	}
@@ -450,15 +500,7 @@ function cinode_recruitment_upload_subcontractor_file($request, $subcontractorId
 		return;
 	}
 
-	$allowed_mimes = array(
-		'pdf'  => 'application/pdf',
-		'doc'  => 'application/msword',
-		'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		'odt'  => 'application/vnd.oasis.opendocument.text',
-		'rtf'  => 'application/rtf',
-		'txt'  => 'text/plain',
-	);
-	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], $allowed_mimes);
+	$file_check = wp_check_filetype_and_ext($files['files']['tmp_name'], $files['files']['name'], cinode_recruitment_allowed_cv_mimes());
 	if (empty($file_check['ext']) || empty($file_check['type'])) {
 		return;
 	}
@@ -506,7 +548,7 @@ function cinode_recruitment_upload_subcontractor_file($request, $subcontractorId
 	return $result;
 }
 
-function cinode_recruitment_import_subcontractor_profile($request, $companyUserId, $companyId, $token)
+function cinode_recruitment_import_user_profile($request, $companyUserId, $companyId, $token)
 {
 	$files    = $request->get_file_params();
 	$tmp_path = $files['files']['tmp_name'] ?? '';
@@ -516,9 +558,18 @@ function cinode_recruitment_import_subcontractor_profile($request, $companyUserI
 		return;
 	}
 
+	$file_check = wp_check_filetype_and_ext($tmp_path, $files['files']['name'], cinode_recruitment_allowed_cv_mimes());
+	if (empty($file_check['ext']) || empty($file_check['type'])) {
+		return;
+	}
+
 	$file_data = file_get_contents($tmp_path);
+	if ($file_data === false) {
+		return;
+	}
+
 	$file_name = $files['files']['name'];
-	$file_type = $files['files']['type'];
+	$file_type = $file_check['type'];
 	$boundary  = cinode_recruitment_boundary();
 
 	$url = 'https://api.cinode.app/v0.1/companies/' . $companyId . '/users/' . $companyUserId . '/profile/import';
@@ -543,6 +594,11 @@ function cinode_recruitment_import_subcontractor_profile($request, $companyUserI
 	);
 
 	return wp_remote_post($url, $args);
+}
+
+function cinode_recruitment_import_subcontractor_profile($request, $companyUserId, $companyId, $token)
+{
+	return cinode_recruitment_import_user_profile($request, $companyUserId, $companyId, $token);
 }
 
 function cinode_recruitment_add_to_subcontractor_group($companyId, $token, $companyUserId, $groupId)
@@ -768,6 +824,10 @@ add_shortcode('cinode', 'cinode_recruitment_shortcode');
 function cinode_recruitment_shortcode($atts = [])
 {
 	$atts = array_change_key_case((array) $atts, CASE_LOWER);
+	$has_shortcode_pipeline_config = array_key_exists('pipelineid', $atts)
+		|| array_key_exists('pipelinestageid', $atts)
+		|| array_key_exists('multiplepipelines', $atts)
+		|| array_key_exists('multiplepipeline_stageid', $atts);
 
 	$args = shortcode_atts(array(
 		'pipelineid' => 0,
@@ -828,6 +888,23 @@ function cinode_recruitment_shortcode($atts = [])
 	$subcontractor_group_sel     = $args['subcontractor_group_selection'] !== '' ? $args['subcontractor_group_selection'] : ($cinode_options['option_subcontractor_group_selection'] ?? 'single');
 	$auto_group_ids              = $args['auto_subcontractor_group_ids'] !== '' ? $args['auto_subcontractor_group_ids'] : ($cinode_options['option_auto_subcontractor_group_ids'] ?? '');
 	$is_subcontractor = $args['recipient_type'] === 'subcontractor';
+	$effective_pipeline_id = 0;
+	$effective_pipeline_stage_id = 0;
+
+	if (!$is_subcontractor) {
+		if ($has_shortcode_pipeline_config) {
+			$effective_pipeline_id = intval($args['pipelineid']);
+			$effective_pipeline_stage_id = intval($args['pipelinestageid']);
+		} else {
+			$default_pipeline_id = intval($cinode_options['option_default_candidate_pipeline_id'] ?? 0);
+			$default_pipeline_stage_id = intval($cinode_options['option_default_candidate_pipeline_stage_id'] ?? 0);
+
+			if ($default_pipeline_id > 0 && $default_pipeline_stage_id > 0) {
+				$effective_pipeline_id = $default_pipeline_id;
+				$effective_pipeline_stage_id = $default_pipeline_stage_id;
+			}
+		}
+	}
 
 	// Unique counter so multiple shortcodes on the same page each get
 	// distinct element IDs and their own per-form JS configuration.
@@ -845,8 +922,8 @@ function cinode_recruitment_shortcode($atts = [])
 
 		<h2><?php echo esc_html($args['formtitle']); ?></h2>
 		<div role="form" class="cinode-form"
-			data-pipeline-id="<?php echo intval($args['pipelineid']); ?>"
-			data-pipeline-stage-id="<?php echo intval($args['pipelinestageid']); ?>"
+			data-pipeline-id="<?php echo intval($effective_pipeline_id); ?>"
+			data-pipeline-stage-id="<?php echo intval($effective_pipeline_stage_id); ?>"
 			data-recruitment-manager-id="<?php echo intval($args['recruitmentmanagerid']); ?>"
 			data-team-id="<?php echo intval($args['teamid']); ?>"
 			data-company-address-id="<?php echo intval($args['companyaddressid']); ?>"
@@ -926,7 +1003,7 @@ function cinode_recruitment_shortcode($atts = [])
 					<br>
 					<div for="file-upload-<?php echo esc_attr($uid); ?>" class="custom-file-upload ">
 						<?php echo esc_html($args['attachment_label']); ?><?php if ($cv_required) echo ' *'; ?>
-						<input id="file-upload-<?php echo esc_attr($uid); ?>" class="file-upload" type="file" />
+						<input id="file-upload-<?php echo esc_attr($uid); ?>" class="file-upload" type="file" accept=".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 						<label class="file-name"></label>
 						<?php if ($cv_required) : ?>
 						<span role="alert" id="file-required-<?php echo esc_attr($uid); ?>" class="alert-required cinode-file-required" style="display:none"><?php echo esc_html($args['requiredfield_msg']); ?></span>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/public/class-cinode-recruitment-public.php
+++ b/public/class-cinode-recruitment-public.php
@@ -61,18 +61,6 @@ class Cinode_Recruitment_Public {
 	 */
 	public function enqueue_styles() {
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Cinode_Recruitment_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Cinode_Recruitment_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
 		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/cinode-recruitment-public.css', array(), $this->version, 'all' );
 
 	}
@@ -83,18 +71,6 @@ class Cinode_Recruitment_Public {
 	 * @since    1.0.0
 	 */
 	public function enqueue_scripts() {
-
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Cinode_Recruitment_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Cinode_Recruitment_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/cinode-recruitment-public.js', array( 'jquery' ), $this->version, false );
 		

--- a/public/js/cinode-recruitment-public.js
+++ b/public/js/cinode-recruitment-public.js
@@ -1,185 +1,216 @@
-var $ = jQuery.noConflict()
-var index = '';
+var $ = jQuery.noConflict();
 
 jQuery(document).ready(function ($) {
-  
-  var isFormClickable = true;
 
-  $(".cinode-form").click(function () {
-    if (!isFormClickable) {
-      return; 
-    }
-
-    var clickedForm = $(this);
-    index = $(".cinode-form").index(clickedForm);
-
-    isFormClickable = false;
-
-    setTimeout(function () {
-      isFormClickable = true;
-    }, 1000); 
-  });
-
-
-  $(".cinode-form #file-upload").change(function () {
-    var fileName = $(".cinode-form:eq("+index+") #file-upload").prop("files")[0].name;
-
-    var fileText = $(".cinode-form").eq(index).find(".file-name");
-    fileText.text(fileName);
-  
-    setTimeout(function () {
-      isFormClickable = true;
-    }, 1000); 
+  // File name display – scoped to the form that owns the file input.
+  // Uses event delegation so it works even when forms are added dynamically.
+  $(document).on('change', '.cinode-form input.file-upload', function () {
+    var files = this.files;
+    var fileName = files && files[0] ? files[0].name : '';
+    $(this).closest('.cinode-form').find('.file-name').text(fileName);
   });
 
   $('.cinode-form').submit(function (event) {
     event.preventDefault();
     var currentForm = $(this);
 
-    currentForm.find(".spinner").show();
-    const email = currentForm.find("#email-input");
-    const first_name = currentForm.find("#first_name-input");
-    const last_name = currentForm.find("#last_name-input");
-    const phone = currentForm.find("#phone-input");
-    const description = currentForm.find("textarea#description-input");
-    const linkedInUrl = currentForm.find("#LinkedInUrl");
-    const companyAddressSelect = currentForm.find("#companyAddressId option:selected");
-    const multiplePipeline = currentForm.find("#selectedPipelineId option:selected").val();
-    const multipleStageId = currentForm.find("#selectedPipelineId option:selected").attr(
-      "stageId"
-    );
-    const file = currentForm.find("input.file-upload")[0].files[0];
-    const terms = currentForm.find("#terms");
-    const availableFrom = currentForm.find("#availableFrom");
+    // ----------------------------------------------------------------
+    // Read per-form configuration from data-* attributes written by the
+    // PHP shortcode.  This allows multiple shortcodes on the same page
+    // to each carry their own independent settings without relying on
+    // globally-scoped JS variables that would be overwritten.
+    // ----------------------------------------------------------------
+    var pipelineId           = parseInt(currentForm.data('pipeline-id') || 0, 10);
+    var pipelineStageId      = parseInt(currentForm.data('pipeline-stage-id') || 0, 10);
+    var recruitmentManagerId = parseInt(currentForm.data('recruitment-manager-id') || 0, 10);
+    var teamId               = parseInt(currentForm.data('team-id') || 0, 10);
+    var companyAddressId     = parseInt(currentForm.data('company-address-id') || 0, 10);
+    var recruitmentSourceId  = parseInt(currentForm.data('recruitment-source-id') || 0, 10);
+    var campaignCode         = currentForm.data('campaign-code') || '';
+    var currencyId           = parseInt(currentForm.data('currency-id') || 1, 10);
+    var recipientType        = currentForm.data('recipient-type') || 'candidate';
+    var cvRequired           = currentForm.data('cv-required') === true;
+    var parseCV              = currentForm.data('parse-cv') === true;
+    var autoSubcontractorGroupIds = currentForm.data('auto-subcontractor-group-ids') || [];
+
+    currentForm.find('.spinner').show();
+
+    // Field references – use name/type attributes so duplicate IDs across
+    // multiple shortcode instances on the same page are never an issue.
+    var email       = currentForm.find("input[name='email']");
+    var first_name  = currentForm.find("input[name='first_name']");
+    var last_name   = currentForm.find("input[name='last_name']");
+    var phone       = currentForm.find("input[name='phone']");
+    var description = currentForm.find("textarea[name='Description']");
+    var linkedInUrl = currentForm.find("input[name='LinkedInUrl']");
+    var companyAddressSelect = currentForm.find("select[name='companyAddressId'] option:selected");
+    var multiplePipeline = currentForm.find("select[name='selectedPipelineId'] option:selected").val();
+    var multipleStageId  = currentForm.find("select[name='selectedPipelineId'] option:selected").attr('stageId');
+    var file        = currentForm.find('input.file-upload')[0].files[0];
+    var terms       = currentForm.find("input[name='terms']");
+    var availableFrom = currentForm.find("input[name='availableFrom']");
+    var gender      = currentForm.find("select[name='gender']");
+
+    // Collect subcontractor group IDs (checkboxes or single select).
+    var subcontractorGroupIds = [];
+    currentForm.find('input[name="subcontractorGroupIds[]"]:checked').each(function () {
+      subcontractorGroupIds.push($(this).val());
+    });
+    var groupSelect = currentForm.find('select[name="subcontractorGroupIds[]"]');
+    if (groupSelect.length > 0 && groupSelect.val()) {
+      subcontractorGroupIds.push(groupSelect.val());
+    }
 
     var formData = new FormData();
     if (terms[0].checked) {
-      currentForm.find("#terms-validate").hide();
+      currentForm.find('.cinode-terms-validate').hide();
       var errorMessages = validateRequiredInputs();
       if (errorMessages.length === 0) {
-        formData.append("files", file);
-        formData.append("firstName", first_name.val());
-        formData.append("lastName", last_name.val());
-        formData.append("email", email.val());
-        formData.append("phone", phone.val());
-        formData.append("description", description.val());
-        formData.append("linkedInUrl", linkedInUrl.val());
-        formData.append("state", 0);
-        formData.append("currencyId", currencyId);
+        if (file) {
+          formData.append('files', file);
+        }
+        formData.append('firstName', first_name.val());
+        formData.append('lastName', last_name.val());
+        formData.append('email', email.val());
+        formData.append('phone', phone.val());
+        formData.append('description', description.val());
+        formData.append('linkedInUrl', linkedInUrl.val());
+        formData.append('state', 0);
+        formData.append('currencyId', currencyId);
+        formData.append('recipient_type', recipientType);
+        formData.append('parse_cv', parseCV ? '1' : '0');
 
-        if (pipelineId) {
-          formData.append("pipelineId", pipelineId);
-        } else if (multiplePipeline) {
-          formData.append("pipelineId", multiplePipeline);
+        if (recipientType === 'subcontractor') {
+          formData.append('gender', gender.length > 0 ? gender.val() : '0');
+          // User-selected groups (from visible selector).
+          subcontractorGroupIds.forEach(function (id) {
+            if (id) { formData.append('subcontractorGroupIds[]', id); }
+          });
+          // Auto-join groups set in admin/shortcode (no visible selector).
+          autoSubcontractorGroupIds.forEach(function (id) {
+            formData.append('subcontractorGroupIds[]', id);
+          });
         }
 
-        if (pipelineStageId) {
-          formData.append("pipelineStageId", pipelineStageId);
-        } else if (multipleStageId) {
-          formData.append("pipelineStageId", multipleStageId);
+        // Subcontractors cannot be placed into pipelines.
+        if (recipientType !== 'subcontractor') {
+          if (pipelineId) {
+            formData.append('pipelineId', pipelineId);
+          } else if (multiplePipeline) {
+            formData.append('pipelineId', multiplePipeline);
+          }
+
+          if (pipelineStageId) {
+            formData.append('pipelineStageId', pipelineStageId);
+          } else if (multipleStageId) {
+            formData.append('pipelineStageId', multipleStageId);
+          }
         }
 
         if (recruitmentManagerId) {
-          formData.append("recruitmentManagerId", recruitmentManagerId);
+          formData.append('recruitmentManagerId', recruitmentManagerId);
         }
         if (teamId) {
-          formData.append("teamId", teamId);
+          formData.append('teamId', teamId);
         }
         if (companyAddressId) {
-          formData.append("companyAddressId", companyAddressId);
-        } else if (companyAddressSelect.length == 1) {
-          formData.append("companyAddressId", companyAddressSelect.val());
+          formData.append('companyAddressId', companyAddressId);
+        } else if (companyAddressSelect.length === 1) {
+          formData.append('companyAddressId', companyAddressSelect.val());
         } else {
-          formData.append("companyAddressId", "");
+          formData.append('companyAddressId', '');
         }
 
         if (availableFrom.length > 0) {
-          formData.append("availableFrom", availableFrom.val());
+          formData.append('availableFrom', availableFrom.val());
         }
 
         if (recruitmentSourceId) {
-          formData.append("recruitmentSourceId", recruitmentSourceId);
+          formData.append('recruitmentSourceId', recruitmentSourceId);
         }
-        formData.append("campaignCode", campaignCode);
-
+        formData.append('campaignCode', campaignCode);
 
         submitRequest(formData, currentForm);
       } else {
-        currentForm.find(".spinner").hide();
+        currentForm.find('.spinner').hide();
       }
     } else {
-      currentForm.find("#terms-validate").show();
-      currentForm.find(".spinner").hide();
+      currentForm.find('.cinode-terms-validate').show();
+      currentForm.find('.spinner').hide();
     }
 
     function validateRequiredInputs() {
       var errorMessage = [];
 
-      if (email.val() === "") {
-        currentForm.find("#email-required").show();
-        errorMessage.push("Aplicant email is missing");
+      var emailReg =
+        /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+      if (email.val() === '' || !emailReg.test(email.val())) {
+        currentForm.find('.cinode-email-required').show();
+        errorMessage.push('Applicant email is missing or invalid');
       } else {
-        errorMessage = errorMessage.filter(
-          (message) => message !== "Aplicant email is missing"
-        );
-        currentForm.find("#email-required").hide();
-      }
-      var emailReg = /^([\w-\.]+@([\w-]+\.)+[\w-]{2,4})?$/;
-      if (!emailReg.test(email.val())) {
-        currentForm.find("#email-required").show();
+        currentForm.find('.cinode-email-required').hide();
       }
 
-      if (first_name.val() === "") {
-        errorMessage.push("First Name is missing");
-        currentForm.find("#first_name-required").show();
+      if (first_name.val() === '') {
+        errorMessage.push('First Name is missing');
+        currentForm.find('.cinode-firstname-required').show();
       } else {
-        errorMessage = errorMessage.filter((message) => message !== "First Name is missing");
-        currentForm.find("#first_name-required").hide();
+        currentForm.find('.cinode-firstname-required').hide();
       }
-      if (last_name.val() === "") {
-        errorMessage.push("Last Name is missing");
-        currentForm.find("#last_name-required").show();
+
+      if (last_name.val() === '') {
+        errorMessage.push('Last Name is missing');
+        currentForm.find('.cinode-lastname-required').show();
       } else {
-        errorMessage = errorMessage.filter((message) => message !== "Last Name is missing");
-        currentForm.find("#last_name-required").hide();
+        currentForm.find('.cinode-lastname-required').hide();
+      }
+
+      // CV required validation.
+      if (cvRequired && !file) {
+        currentForm.find('.cinode-file-required').show();
+        errorMessage.push('CV file is required');
+      } else {
+        currentForm.find('.cinode-file-required').hide();
+      }
+
+      // Gender required for subcontractor mode.
+      if (recipientType === 'subcontractor' && gender.length > 0 && (gender.val() === null || gender.val() === '')) {
+        currentForm.find('.cinode-gender-required').show();
+        errorMessage.push('Gender is required');
+      } else {
+        currentForm.find('.cinode-gender-required').hide();
       }
 
       return errorMessage;
     }
 
     function submitRequest(data, currentForm) {
-      currentForm.find(".spinner").show();
-      var url = cinode_url.site_url;
-      var path = url + "/wp-json/cinode/v2/cinode-recruitment";
+      currentForm.find('.spinner').show();
+      var path = cinode_url.site_url + '/wp-json/cinode/v2/cinode-recruitment';
 
       $.ajax({
-        type: "POST",
+        type: 'POST',
         url: path,
         data: data,
         contentType: false,
         processData: false,
         success: function (response) {
-          if (response.response.code == 201) {
-            currentForm.find(".spinner").hide();
-            currentForm.find("#successful-submit-msg").show(300);
+          if (response.status === 201) {
+            currentForm.find('.spinner').hide();
+            currentForm.find('.cinode-success-msg').show(300);
             setTimeout(function () {
-              currentForm.find("#successful-submit-msg").fadeOut("fast");
+              currentForm.find('.cinode-success-msg').fadeOut('fast');
             }, 5000);
-            currentForm.find("input:checkbox").removeAttr("checked");
-            currentForm.find(":input").not(":button, :submit, :reset, :hidden").val("");
-            currentForm.find("#file-name").text("");
-          } else if (response.response.code == 401) {
-            currentForm.find("#unsuccessful-submit-msg").show(300);
+            currentForm.find('input:checkbox').removeAttr('checked');
+            currentForm.find(':input').not(':button, :submit, :reset, :hidden').val('');
+            currentForm.find('.file-name').text('');
+          } else {
+            currentForm.find('.cinode-error-msg').show(300);
             setTimeout(function () {
-              currentForm.find("#unsuccessful-submit-msg").fadeOut("fast");
+              currentForm.find('.cinode-error-msg').fadeOut('fast');
             }, 6000);
-            currentForm.find(".spinner").hide();
-          }else{
-            currentForm.find("#unsuccessful-submit-msg").show(300);
-            setTimeout(function () {
-              currentForm.find("#unsuccessful-submit-msg").fadeOut("fast");
-            }, 6000);
-            currentForm.find(".spinner").hide();
+            currentForm.find('.spinner').hide();
           }
         },
       });

--- a/tests/CinodeRecruitmentTest.php
+++ b/tests/CinodeRecruitmentTest.php
@@ -150,7 +150,7 @@ class CinodeRecruitmentTest extends TestCase
         $this->assertSame('jane@example.com', $body['email']);
         $this->assertTrue($body['createProfile']);
         $this->assertSame(714, $body['languageId']);
-        $this->assertSame(714, $body['profileLanguageId']);
+        $this->assertArrayNotHasKey('profileLanguageId', $body);
         // Password pair must match
         $this->assertSame($body['password'], $body['confirmPassword']);
         $this->assertNotEmpty($body['password']);
@@ -169,7 +169,7 @@ class CinodeRecruitmentTest extends TestCase
 
         $body = json_decode($this->httpLog[0]['args']['body'], true);
         $this->assertSame(123, $body['languageId']);
-        $this->assertSame(123, $body['profileLanguageId']);
+        $this->assertArrayNotHasKey('profileLanguageId', $body);
     }
 
     #[Test]

--- a/tests/CinodeRecruitmentTest.php
+++ b/tests/CinodeRecruitmentTest.php
@@ -1,0 +1,1214 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for cinode_recruitment_create_candidate_user(),
+ * cinode_recruitment_multipart_post(), and
+ * cinode_recruitment_get_company_user_id().
+ *
+ * WordPress HTTP calls are intercepted via a global callback
+ * ($GLOBALS['__pre_http_request']) that mirrors WP's own
+ * pre_http_request filter pattern.
+ */
+class CinodeRecruitmentTest extends TestCase
+{
+    /** @var list<array{url: string, args: array}> */
+    private array $httpLog = [];
+
+    protected function setUp(): void
+    {
+        $this->httpLog = [];
+
+        // Sensible option defaults
+        $GLOBALS['__wp_options'] = [
+            'cinode_recruitment_options' => [
+                'option_companyId' => '42',
+                'option_apiKey'    => 'test-token',
+                'option_subcontractor_default_language_id' => '714',
+            ],
+            'cinode_recruitment_options_sendmail' => [
+                'option_subject' => 'Application received',
+                'option_message' => 'Thank you for your application.',
+            ],
+        ];
+
+        $GLOBALS['__wp_transients'] = [];
+        $GLOBALS['__wp_mail_log'] = [];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['__pre_http_request']);
+    }
+
+    /* ------------------------------------------------------------------
+     * Helper: install a fake HTTP responder and log every request.
+     * ----------------------------------------------------------------*/
+    private function fakeHttp(int $statusCode, array $body = []): void
+    {
+        $log = &$this->httpLog;
+        $GLOBALS['__pre_http_request'] = function (string $url, array $args) use ($statusCode, $body, &$log) {
+            $log[] = ['url' => $url, 'args' => $args];
+            return [
+                'response' => ['code' => $statusCode],
+                'body'     => json_encode($body),
+            ];
+        };
+    }
+
+    /**
+     * Install a responder that returns a WP_Error.
+     */
+    private function fakeHttpError(string $code = 'http_request_failed', string $message = 'cURL error'): void
+    {
+        $log = &$this->httpLog;
+        $GLOBALS['__pre_http_request'] = function (string $url, array $args) use ($code, $message, &$log) {
+            $log[] = ['url' => $url, 'args' => $args];
+            return new WP_Error($code, $message);
+        };
+    }
+
+    /**
+     * Install a responder that returns successive responses from a list.
+     * Each entry: [statusCode, body?]
+     */
+    private function fakeHttpSequence(array $responses): void
+    {
+        $log = &$this->httpLog;
+        $index = 0;
+        $GLOBALS['__pre_http_request'] = function (string $url, array $args) use (&$responses, &$log, &$index) {
+            $log[] = ['url' => $url, 'args' => $args];
+            $resp = $responses[$index] ?? end($responses);
+            $index++;
+            return [
+                'response' => ['code' => $resp[0]],
+                'body'     => json_encode($resp[1] ?? []),
+            ];
+        };
+    }
+
+    /**
+     * Run a callback while capturing error_log output.
+     */
+    private function captureErrorLog(callable $fn): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'phpunit_log_');
+        $prev = ini_set('error_log', $tmp);
+        try {
+            $fn();
+        } finally {
+            ini_set('error_log', $prev);
+        }
+        $contents = file_get_contents($tmp);
+        unlink($tmp);
+        return $contents !== false ? $contents : '';
+    }
+
+    /* ==================================================================
+     * 1. cinode_recruitment_create_candidate_user()
+     * ================================================================*/
+
+    #[Test]
+    public function create_candidate_user_sends_correct_url_and_json_body(): void
+    {
+        $this->fakeHttp(201, ['companyUserId' => 99]);
+
+        $postData = [
+            'firstName' => 'Jane',
+            'lastName'  => 'Doe',
+            'email'     => 'jane@example.com',
+        ];
+
+        $result = cinode_recruitment_create_candidate_user($postData, 7, '42', 'my-token');
+
+        // Returned user ID
+        $this->assertSame(99, $result);
+
+        // Exactly one HTTP call
+        $this->assertCount(1, $this->httpLog);
+
+        $req = $this->httpLog[0];
+
+        // URL includes company + candidate IDs
+        $this->assertSame(
+            'https://api.cinode.app/v0.1/companies/42/candidates/7/user',
+            $req['url']
+        );
+
+        // Headers
+        $this->assertSame('application/json', $req['args']['headers']['Content-Type']);
+        $this->assertSame('Bearer my-token', $req['args']['headers']['Authorization']);
+
+        // Body payload
+        $body = json_decode($req['args']['body'], true);
+        $this->assertSame('Jane', $body['firstName']);
+        $this->assertSame('Doe', $body['lastName']);
+        $this->assertSame('jane@example.com', $body['email']);
+        $this->assertTrue($body['createProfile']);
+        $this->assertSame(714, $body['languageId']);
+        $this->assertSame(714, $body['profileLanguageId']);
+        // Password pair must match
+        $this->assertSame($body['password'], $body['confirmPassword']);
+        $this->assertNotEmpty($body['password']);
+    }
+
+    #[Test]
+    public function create_candidate_user_uses_configured_language_id(): void
+    {
+        $GLOBALS['__wp_options']['cinode_recruitment_options']['option_subcontractor_default_language_id'] = '123';
+        $this->fakeHttp(200, ['companyUserId' => 5]);
+
+        $result = cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'a@b.com'],
+            1, '42', 'tok'
+        );
+
+        $body = json_decode($this->httpLog[0]['args']['body'], true);
+        $this->assertSame(123, $body['languageId']);
+        $this->assertSame(123, $body['profileLanguageId']);
+    }
+
+    #[Test]
+    public function create_candidate_user_defaults_language_to_714_when_missing(): void
+    {
+        unset($GLOBALS['__wp_options']['cinode_recruitment_options']['option_subcontractor_default_language_id']);
+        $this->fakeHttp(200, ['companyUserId' => 5]);
+
+        cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'a@b.com'],
+            1, '42', 'tok'
+        );
+
+        $body = json_decode($this->httpLog[0]['args']['body'], true);
+        $this->assertSame(714, $body['languageId']);
+    }
+
+    #[Test]
+    public function create_candidate_user_returns_null_on_non_200_response(): void
+    {
+        $this->fakeHttp(400, ['error' => 'bad request']);
+
+        $result = cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'a@b.com'],
+            1, '42', 'tok'
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function create_candidate_user_returns_null_on_500(): void
+    {
+        $this->fakeHttp(500);
+
+        $result = cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'x@y.com'],
+            1, '42', 'tok'
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function create_candidate_user_returns_null_and_logs_on_wp_error(): void
+    {
+        $this->fakeHttpError('http_request_failed', 'Connection timed out');
+
+        $logged = $this->captureErrorLog(function () {
+            $result = cinode_recruitment_create_candidate_user(
+                ['firstName' => 'A', 'lastName' => 'B', 'email' => 'x@y.com'],
+                1, '42', 'tok'
+            );
+            $this->assertNull($result);
+        });
+
+        $this->assertStringContainsString('candidate user create failed', $logged);
+        $this->assertStringContainsString('Connection timed out', $logged);
+    }
+
+    #[Test]
+    public function create_candidate_user_extracts_nested_company_user_id(): void
+    {
+        // Some API responses nest the ID under companyUser.id
+        $this->fakeHttp(201, [
+            'companyUser' => ['id' => 77],
+        ]);
+
+        $result = cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'a@b.com'],
+            1, '42', 'tok'
+        );
+
+        $this->assertSame(77, $result);
+    }
+
+    #[Test]
+    public function create_candidate_user_accepts_200_as_success(): void
+    {
+        $this->fakeHttp(200, ['companyUserId' => 12]);
+
+        $result = cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'a@b.com'],
+            1, '42', 'tok'
+        );
+
+        $this->assertSame(12, $result);
+    }
+
+    #[Test]
+    public function create_candidate_user_intcasts_candidate_id_in_url(): void
+    {
+        $this->fakeHttp(201, ['companyUserId' => 1]);
+
+        cinode_recruitment_create_candidate_user(
+            ['firstName' => 'A', 'lastName' => 'B', 'email' => 'a@b.com'],
+            '9abc', // non-numeric suffix should be stripped by intval()
+            '42',
+            'tok'
+        );
+
+        $this->assertStringContainsString('/candidates/9/user', $this->httpLog[0]['url']);
+    }
+
+    /* ==================================================================
+     * 2. cinode_recruitment_get_company_user_id()
+     * ================================================================*/
+
+    #[Test]
+    public function get_company_user_id_returns_null_for_non_array(): void
+    {
+        $this->assertNull(cinode_recruitment_get_company_user_id(null));
+        $this->assertNull(cinode_recruitment_get_company_user_id('string'));
+    }
+
+    #[Test]
+    public function get_company_user_id_from_top_level_key(): void
+    {
+        $this->assertSame(42, cinode_recruitment_get_company_user_id(['companyUserId' => 42]));
+    }
+
+    #[Test]
+    public function get_company_user_id_from_nested_company_user(): void
+    {
+        $this->assertSame(7, cinode_recruitment_get_company_user_id([
+            'companyUser' => ['companyUserId' => 7],
+        ]));
+    }
+
+    #[Test]
+    public function get_company_user_id_falls_back_to_nested_id(): void
+    {
+        $this->assertSame(3, cinode_recruitment_get_company_user_id([
+            'companyUser' => ['id' => 3],
+        ]));
+    }
+
+    #[Test]
+    public function get_company_user_id_returns_null_for_zero(): void
+    {
+        $this->assertNull(cinode_recruitment_get_company_user_id(['companyUserId' => 0]));
+    }
+
+    /* ==================================================================
+     * 3. cinode_recruitment_multipart_post()
+     * ================================================================*/
+
+    #[Test]
+    public function multipart_post_body_has_closing_boundary(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [['name' => 'title', 'data' => 'hello']]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        // RFC 2046: closing boundary is "--<boundary>--"
+        $this->assertMatchesRegularExpression('/^--[A-Za-z0-9]+--\r\n$/m', substr($body, strrpos($body, "\r\n--") + 2));
+    }
+
+    #[Test]
+    public function multipart_post_formats_plain_field_without_filename(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [['name' => 'ImportSkills', 'data' => 'true']]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('Content-Disposition: form-data; name="ImportSkills"', $body);
+        $this->assertStringNotContainsString('filename', $body);
+        $this->assertStringContainsString("true\r\n", $body);
+    }
+
+    #[Test]
+    public function multipart_post_formats_file_part_with_content_type(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [[
+                'name'     => 'File',
+                'filename' => 'cv.pdf',
+                'type'     => 'application/pdf',
+                'data'     => '%PDF-fake-content',
+            ]]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('Content-Disposition: form-data; name="File"; filename="cv.pdf"', $body);
+        $this->assertStringContainsString('Content-Type: application/pdf', $body);
+        $this->assertStringContainsString('%PDF-fake-content', $body);
+    }
+
+    #[Test]
+    public function multipart_post_sends_bearer_token_and_correct_content_type(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'my-secret-token',
+            [['name' => 'title', 'data' => 'y']]
+        );
+
+        $headers = $this->httpLog[0]['args']['headers'];
+        $this->assertSame('Bearer my-secret-token', $headers['Authorization']);
+        $this->assertStringStartsWith('multipart/form-data; boundary=', $headers['Content-Type']);
+
+        // Extract boundary from Content-Type header and verify body uses it
+        preg_match('/boundary=(.+)$/', $headers['Content-Type'], $m);
+        $boundary = $m[1];
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('--' . $boundary, $body);
+        $this->assertStringContainsString('--' . $boundary . '--', $body);
+    }
+
+    #[Test]
+    public function multipart_post_includes_multiple_parts_in_order(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'files', 'filename' => 'cv.pdf', 'type' => 'application/pdf', 'data' => 'pdfdata'],
+                ['name' => 'title', 'data' => 'My CV'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+
+        // file part must come before title part
+        $filePos  = strpos($body, 'name="files"');
+        $titlePos = strpos($body, 'name="title"');
+        $this->assertNotFalse($filePos);
+        $this->assertNotFalse($titlePos);
+        $this->assertLessThan($titlePos, $filePos);
+    }
+
+    #[Test]
+    public function multipart_post_sets_timeout_when_positive(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [['name' => 'title', 'data' => 'y']],
+            30
+        );
+
+        $this->assertSame(30, $this->httpLog[0]['args']['timeout']);
+    }
+
+    #[Test]
+    public function multipart_post_omits_timeout_when_zero(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [['name' => 'title', 'data' => 'y']],
+            0
+        );
+
+        $this->assertArrayNotHasKey('timeout', $this->httpLog[0]['args']);
+    }
+
+    /* ==================================================================
+     * 4. Header-injection prevention
+     * ================================================================*/
+
+    #[Test]
+    public function multipart_post_strips_quotes_and_crlf_from_filename(): void
+    {
+        $this->fakeHttp(200);
+
+        $malicious = "cv\".pdf\r\nX-Injected: true";
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [[
+                'name'     => 'files',
+                'filename' => $malicious,
+                'type'     => 'application/pdf',
+                'data'     => 'data',
+            ]]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+
+        // No double-quote inside the filename value
+        // The pattern captures the filename="..." value
+        preg_match('/filename="([^"]*)"/', $body, $m);
+        $this->assertNotEmpty($m, 'filename should be present in Content-Disposition');
+        $sanitised = $m[1];
+        $this->assertStringNotContainsString('"', $sanitised);
+        $this->assertStringNotContainsString("\r", $sanitised);
+        $this->assertStringNotContainsString("\n", $sanitised);
+
+        // The injected text must not appear as its own header line
+        // (it may be folded into the filename value, which is safe)
+        $this->assertDoesNotMatchRegularExpression('/^X-Injected:/m', $body);
+    }
+
+    #[Test]
+    public function multipart_post_strips_null_bytes_from_filename(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [[
+                'name'     => 'files',
+                'filename' => "cv\0.pdf",
+                'type'     => 'application/pdf',
+                'data'     => 'data',
+            ]]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringNotContainsString("\0", $body);
+    }
+
+    #[Test]
+    public function multipart_post_strips_crlf_from_content_type(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [[
+                'name'     => 'files',
+                'filename' => 'cv.pdf',
+                'type'     => "application/pdf\r\nX-Injected: true",
+                'data'     => 'data',
+            ]]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        // Must not appear as a separate header line (CRLF injection neutralised)
+        $this->assertDoesNotMatchRegularExpression('/^X-Injected:/m', $body);
+        // Verify CR/LF are gone from the Content-Type value itself
+        preg_match('/^Content-Type: (.+?)\r?$/m', $body, $ct);
+        $this->assertNotEmpty($ct);
+        $this->assertStringNotContainsString("\r", $ct[1]);
+        $this->assertStringNotContainsString("\n", $ct[1]);
+    }
+
+    #[Test]
+    public function multipart_post_drops_parts_with_unknown_name(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'files', 'filename' => 'cv.pdf', 'type' => 'application/pdf', 'data' => 'pdfdata'],
+                ['name' => 'evil_field', 'data' => 'should be dropped'],
+                ['name' => 'title', 'data' => 'My CV'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('name="files"', $body);
+        $this->assertStringContainsString('name="title"', $body);
+        $this->assertStringNotContainsString('evil_field', $body);
+        $this->assertStringNotContainsString('should be dropped', $body);
+    }
+
+    #[Test]
+    public function multipart_post_accepts_all_known_name_values(): void
+    {
+        $this->fakeHttp(200);
+
+        // All four known names used across call sites
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'files', 'filename' => 'a.pdf', 'type' => 'application/pdf', 'data' => '1'],
+                ['name' => 'File',  'filename' => 'b.pdf', 'type' => 'application/pdf', 'data' => '2'],
+                ['name' => 'title', 'data' => 'T'],
+                ['name' => 'ImportSkills', 'data' => 'true'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('name="files"', $body);
+        $this->assertStringContainsString('name="File"', $body);
+        $this->assertStringContainsString('name="title"', $body);
+        $this->assertStringContainsString('name="ImportSkills"', $body);
+    }
+
+    #[Test]
+    public function sanitize_multipart_filename_handles_path_traversal(): void
+    {
+        $result = cinode_recruitment_sanitize_multipart_filename('../../etc/passwd');
+        $this->assertStringNotContainsString('..', $result);
+        $this->assertStringNotContainsString('/', $result);
+    }
+
+    /* ==================================================================
+     * 5. Part validation & optional content-type for non-file fields
+     * ================================================================*/
+
+    #[Test]
+    public function multipart_post_skips_part_missing_data(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'title'],                         // no 'data' key
+                ['name' => 'ImportSkills', 'data' => 'true'], // valid
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringNotContainsString('name="title"', $body);
+        $this->assertStringContainsString('name="ImportSkills"', $body);
+    }
+
+    #[Test]
+    public function multipart_post_skips_file_part_missing_data(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'files', 'filename' => 'cv.pdf', 'type' => 'application/pdf'],
+                ['name' => 'title', 'data' => 'My CV'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringNotContainsString('name="files"', $body);
+        $this->assertStringContainsString('name="title"', $body);
+    }
+
+    #[Test]
+    public function multipart_post_file_part_defaults_type_when_missing(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'files', 'filename' => 'cv.pdf', 'data' => 'pdfdata'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('Content-Type: application/octet-stream', $body);
+    }
+
+    #[Test]
+    public function multipart_post_non_file_part_emits_content_type_when_set(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'ImportSkills', 'data' => 'true', 'type' => 'text/plain'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('name="ImportSkills"', $body);
+        $this->assertStringContainsString('Content-Type: text/plain', $body);
+        // Must not have a filename
+        $this->assertStringNotContainsString('filename', $body);
+    }
+
+    #[Test]
+    public function multipart_post_non_file_part_omits_content_type_by_default(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['name' => 'title', 'data' => 'hello'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringContainsString('name="title"', $body);
+        $this->assertStringNotContainsString('Content-Type:', $body);
+    }
+
+    #[Test]
+    public function multipart_post_skips_part_missing_name(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_multipart_post(
+            'https://example.com/upload',
+            'tok',
+            [
+                ['data' => 'orphan value'],
+                ['name' => 'title', 'data' => 'ok'],
+            ]
+        );
+
+        $body = $this->httpLog[0]['args']['body'];
+        $this->assertStringNotContainsString('orphan value', $body);
+        $this->assertStringContainsString('name="title"', $body);
+    }
+
+    /* ==================================================================
+     * 6. WP_Error handling in candidate/subcontractor post flows
+     * ================================================================*/
+
+    private function makePostData(array $overrides = []): FakeWPRestRequest
+    {
+        return new FakeWPRestRequest(array_merge([
+            'firstName'   => 'Jane',
+            'lastName'    => 'Doe',
+            'email'       => 'jane@example.com',
+            'phone'       => '555-1234',
+            'description' => 'Hello',
+            'linkedInUrl' => 'https://linkedin.com/in/jane',
+            'state'       => '0',
+            'currencyId'  => '1',
+        ], $overrides));
+    }
+
+    #[Test]
+    public function candidate_post_returns_500_on_wp_error(): void
+    {
+        $this->fakeHttpError('http_request_failed', 'DNS resolution failed');
+
+        $request = $this->makePostData();
+
+        $logged = $this->captureErrorLog(function () use ($request) {
+            $response = cinodeRecruitmentPost($request);
+            $this->assertInstanceOf(WP_REST_Response::class, $response);
+            $this->assertSame(500, $response->status);
+        });
+
+        $this->assertStringContainsString('candidate create failed', $logged);
+        $this->assertStringContainsString('DNS resolution failed', $logged);
+    }
+
+    #[Test]
+    public function subcontractor_post_returns_500_on_wp_error(): void
+    {
+        $this->fakeHttpError('http_request_failed', 'SSL handshake failed');
+
+        $request = $this->makePostData(['recipient_type' => 'subcontractor']);
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        $logged = $this->captureErrorLog(function () use ($request, $options) {
+            $response = cinode_recruitment_create_subcontractor(
+                $request, '42', 'test-token', $options
+            );
+            $this->assertInstanceOf(WP_REST_Response::class, $response);
+            $this->assertSame(500, $response->status);
+        });
+
+        $this->assertStringContainsString('subcontractor create failed', $logged);
+        $this->assertStringContainsString('SSL handshake failed', $logged);
+    }
+
+    #[Test]
+    public function candidate_post_does_not_send_mail_on_wp_error(): void
+    {
+        $this->fakeHttpError();
+
+        $request = $this->makePostData();
+        $this->captureErrorLog(function () use ($request) {
+            cinodeRecruitmentPost($request);
+        });
+
+        // Only one HTTP call (the failed post); no mail-related calls follow
+        $this->assertCount(1, $this->httpLog);
+    }
+
+    /* ==================================================================
+     * 7. cinodeRecruitmentPost() – candidate success path
+     * ================================================================*/
+
+    #[Test]
+    public function candidate_post_success_sends_correct_url_and_body(): void
+    {
+        $this->fakeHttp(201, ['id' => 5]);
+
+        $request = $this->makePostData();
+        $response = cinodeRecruitmentPost($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(201, $response->status);
+
+        $req = $this->httpLog[0];
+        $this->assertSame('https://api.cinode.app/v0.1/companies/42/candidates', $req['url']);
+        $this->assertSame('Bearer test-token', $req['args']['headers']['Authorization']);
+
+        $body = json_decode($req['args']['body'], true);
+        $this->assertSame('Jane', $body['firstName']);
+        $this->assertSame('Doe', $body['lastName']);
+        $this->assertSame('Hello', $body['description']);
+        $this->assertSame('jane@example.com', $body['email']);
+        $this->assertSame('555-1234', $body['phone']);
+        $this->assertSame('https://linkedin.com/in/jane', $body['linkedInUrl']);
+    }
+
+    #[Test]
+    public function candidate_post_includes_optional_int_fields_only_when_positive(): void
+    {
+        $this->fakeHttp(201, ['id' => 5]);
+
+        $request = $this->makePostData([
+            'pipelineId'           => '3',
+            'pipelineStageId'      => '0',
+            'recruitmentManagerId' => '7',
+            'teamId'               => '0',
+            'companyAddressId'     => '2',
+            'recruitmentSourceId'  => '9',
+        ]);
+        cinodeRecruitmentPost($request);
+
+        $body = json_decode($this->httpLog[0]['args']['body'], true);
+        $this->assertSame(3, $body['pipelineId']);
+        $this->assertArrayNotHasKey('pipelineStageId', $body);
+        $this->assertSame(7, $body['recruitmentManagerId']);
+        $this->assertArrayNotHasKey('teamId', $body);
+        $this->assertSame(2, $body['companyAddressId']);
+        $this->assertSame(9, $body['recruitmentSourceId']);
+    }
+
+    #[Test]
+    public function candidate_post_includes_optional_string_fields_when_set(): void
+    {
+        $this->fakeHttp(201, ['id' => 5]);
+
+        $request = $this->makePostData([
+            'availableFrom' => '2025-06-01',
+            'campaignCode'  => 'SUMMER25',
+        ]);
+        cinodeRecruitmentPost($request);
+
+        $body = json_decode($this->httpLog[0]['args']['body'], true);
+        $this->assertSame('2025-06-01', $body['availableFromDate']);
+        $this->assertSame('SUMMER25', $body['campaignCode']);
+    }
+
+    #[Test]
+    public function candidate_post_excludes_optional_string_fields_when_empty(): void
+    {
+        $this->fakeHttp(201, ['id' => 5]);
+
+        $request = $this->makePostData();
+        cinodeRecruitmentPost($request);
+
+        $body = json_decode($this->httpLog[0]['args']['body'], true);
+        $this->assertArrayNotHasKey('availableFromDate', $body);
+        $this->assertArrayNotHasKey('campaignCode', $body);
+    }
+
+    #[Test]
+    public function candidate_post_sends_confirmation_email_on_success(): void
+    {
+        $this->fakeHttp(201, ['id' => 5]);
+
+        $request = $this->makePostData();
+        cinodeRecruitmentPost($request);
+
+        $this->assertCount(1, $GLOBALS['__wp_mail_log']);
+        $this->assertSame('jane@example.com', $GLOBALS['__wp_mail_log'][0][0]);
+        $this->assertSame('Application received', $GLOBALS['__wp_mail_log'][0][1]);
+    }
+
+    #[Test]
+    public function candidate_post_does_not_send_email_on_non_201(): void
+    {
+        $this->fakeHttp(400);
+
+        $request = $this->makePostData();
+        $response = cinodeRecruitmentPost($request);
+
+        $this->assertSame(400, $response->status);
+        $this->assertEmpty($GLOBALS['__wp_mail_log']);
+    }
+
+    #[Test]
+    public function candidate_post_returns_415_for_invalid_cv(): void
+    {
+        // is_uploaded_file() returns false in test context → CV validation fails
+        $request = new FakeWPRestRequest(
+            ['firstName' => 'Jane', 'lastName' => 'Doe', 'email' => 'jane@example.com'],
+            ['files' => ['tmp_name' => '/tmp/fake.pdf', 'name' => 'test.pdf']]
+        );
+
+        $response = cinodeRecruitmentPost($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(415, $response->status);
+        $this->assertEmpty($this->httpLog);
+    }
+
+    #[Test]
+    public function candidate_post_routes_subcontractor_to_correct_endpoint(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData(['recipient_type' => 'subcontractor']);
+        cinodeRecruitmentPost($request);
+
+        $this->assertStringContainsString('/subcontractors', $this->httpLog[0]['url']);
+        $this->assertStringNotContainsString('/candidates', $this->httpLog[0]['url']);
+    }
+
+    /* ==================================================================
+     * 8. cinode_recruitment_create_subcontractor() – success path
+     * ================================================================*/
+
+    #[Test]
+    public function subcontractor_success_sends_correct_url_and_body(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData();
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        $response = cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(201, $response->status);
+
+        $req = $this->httpLog[0];
+        $this->assertSame('https://api.cinode.app/v0.1/companies/42/subcontractors', $req['url']);
+
+        $body = json_decode($req['args']['body'], true);
+        $this->assertSame('Jane', $body['firstName']);
+        $this->assertSame('Doe', $body['lastName']);
+        $this->assertSame('jane@example.com', $body['email']);
+        $this->assertSame(714, $body['languageId']);
+        $this->assertSame(714, $body['profileLanguageId']);
+        $this->assertTrue($body['createProfile']);
+        $this->assertSame($body['password'], $body['passwordConfirm']);
+    }
+
+    #[Test]
+    public function subcontractor_defaults_language_to_714_when_not_configured(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData();
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+        unset($options['option_subcontractor_default_language_id']);
+
+        cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        $body = json_decode($this->httpLog[0]['args']['body'], true);
+        $this->assertSame(714, $body['languageId']);
+    }
+
+    #[Test]
+    public function subcontractor_success_sends_welcome_email_and_confirmation(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData();
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        // Second HTTP call is the welcome email
+        $this->assertCount(2, $this->httpLog);
+        $this->assertSame(
+            'https://api.cinode.app/v0.1/companies/42/subcontractors/10/send-welcome-email',
+            $this->httpLog[1]['url']
+        );
+
+        // wp_mail confirmation
+        $this->assertCount(1, $GLOBALS['__wp_mail_log']);
+        $this->assertSame('jane@example.com', $GLOBALS['__wp_mail_log'][0][0]);
+    }
+
+    #[Test]
+    public function subcontractor_success_adds_to_groups_from_csv(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // group 5
+            [200], // group 8
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData(['subcontractorGroupIds' => '5,8']);
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        // Calls: create, group 5, group 8, welcome email
+        $this->assertCount(4, $this->httpLog);
+        $this->assertStringContainsString('/groups/5/members', $this->httpLog[1]['url']);
+        $this->assertStringContainsString('/groups/8/members', $this->httpLog[2]['url']);
+
+        $group5Body = json_decode($this->httpLog[1]['args']['body'], true);
+        $this->assertSame(20, $group5Body['companyUserSubcontractorId']);
+    }
+
+    #[Test]
+    public function subcontractor_success_adds_to_groups_from_array(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // group 3
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData(['subcontractorGroupIds' => [3]]);
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        $this->assertCount(3, $this->httpLog);
+        $this->assertStringContainsString('/groups/3/members', $this->httpLog[1]['url']);
+    }
+
+    #[Test]
+    public function subcontractor_skips_zero_group_ids(): void
+    {
+        $this->fakeHttpSequence([
+            [201, ['id' => 10, 'companyUserId' => 20]],
+            [200], // welcome email
+        ]);
+
+        $request = $this->makePostData(['subcontractorGroupIds' => '0,0']);
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        // Only create + welcome email; no group calls
+        $this->assertCount(2, $this->httpLog);
+    }
+
+    #[Test]
+    public function subcontractor_non_201_skips_emails_and_groups(): void
+    {
+        $this->fakeHttp(400);
+
+        $request = $this->makePostData(['subcontractorGroupIds' => '5']);
+        $options = $GLOBALS['__wp_options']['cinode_recruitment_options'];
+
+        $response = cinode_recruitment_create_subcontractor($request, '42', 'test-token', $options);
+
+        $this->assertSame(400, $response->status);
+        $this->assertCount(1, $this->httpLog);
+        $this->assertEmpty($GLOBALS['__wp_mail_log']);
+    }
+
+    /* ==================================================================
+     * 9. cinode_recruitment_add_to_subcontractor_group()
+     * ================================================================*/
+
+    #[Test]
+    public function add_to_group_sends_correct_url_body_and_headers(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_add_to_subcontractor_group('42', 'my-token', 55, 7);
+
+        $this->assertCount(1, $this->httpLog);
+        $req = $this->httpLog[0];
+
+        $this->assertSame(
+            'https://api.cinode.app/v0.1/companies/42/subcontractors/groups/7/members',
+            $req['url']
+        );
+
+        $body = json_decode($req['args']['body'], true);
+        $this->assertSame(55, $body['companyUserSubcontractorId']);
+        $this->assertSame('Bearer my-token', $req['args']['headers']['Authorization']);
+    }
+
+    #[Test]
+    public function add_to_group_casts_ids_to_int(): void
+    {
+        $this->fakeHttp(200);
+
+        cinode_recruitment_add_to_subcontractor_group('42', 'tok', '99', '3');
+
+        $req = $this->httpLog[0];
+        $this->assertStringContainsString('/groups/3/members', $req['url']);
+
+        $body = json_decode($req['args']['body'], true);
+        $this->assertSame(99, $body['companyUserSubcontractorId']);
+    }
+
+    /* ==================================================================
+     * 10. cinode_recruitment_uploaded_cv_is_valid()
+     * ================================================================*/
+
+    #[Test]
+    public function cv_valid_returns_true_when_no_files(): void
+    {
+        $request = new FakeWPRestRequest([], []);
+        $this->assertTrue(cinode_recruitment_uploaded_cv_is_valid($request));
+    }
+
+    #[Test]
+    public function cv_valid_returns_true_when_files_key_empty(): void
+    {
+        $request = new FakeWPRestRequest([], ['files' => []]);
+        $this->assertTrue(cinode_recruitment_uploaded_cv_is_valid($request));
+    }
+
+    #[Test]
+    public function cv_valid_returns_false_when_missing_tmp_name(): void
+    {
+        $request = new FakeWPRestRequest([], ['files' => ['name' => 'test.pdf']]);
+        $this->assertFalse(cinode_recruitment_uploaded_cv_is_valid($request));
+    }
+
+    #[Test]
+    public function cv_valid_returns_false_when_missing_name(): void
+    {
+        $request = new FakeWPRestRequest([], ['files' => ['tmp_name' => '/tmp/x.pdf']]);
+        $this->assertFalse(cinode_recruitment_uploaded_cv_is_valid($request));
+    }
+
+    #[Test]
+    public function cv_valid_returns_false_for_non_uploaded_file(): void
+    {
+        // is_uploaded_file() always returns false in test context
+        $request = new FakeWPRestRequest([], [
+            'files' => ['tmp_name' => '/tmp/fake.pdf', 'name' => 'resume.pdf'],
+        ]);
+        $this->assertFalse(cinode_recruitment_uploaded_cv_is_valid($request));
+    }
+
+    /* ==================================================================
+     * 11. cinode_recruitment_apiTokenCheck()
+     * ================================================================*/
+
+    #[Test]
+    public function api_token_check_returns_true_for_valid_response(): void
+    {
+        $this->fakeHttp(200, ['name' => 'Test Company']);
+
+        $result = cinode_recruitment_apiTokenCheck();
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function api_token_check_returns_false_for_empty_response(): void
+    {
+        $this->fakeHttp(200);
+
+        $result = cinode_recruitment_apiTokenCheck();
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function api_token_check_sends_correct_url_and_headers(): void
+    {
+        $this->fakeHttp(200, ['name' => 'X']);
+
+        cinode_recruitment_apiTokenCheck();
+
+        $this->assertCount(1, $this->httpLog);
+        $req = $this->httpLog[0];
+        $this->assertSame('https://api.cinode.app/v0.1/companies/42', $req['url']);
+        $this->assertSame('Bearer test-token', $req['args']['headers']['Authorization']);
+    }
+
+    #[Test]
+    public function api_token_check_caches_result(): void
+    {
+        $this->fakeHttp(200, ['name' => 'Test Company']);
+
+        $first  = cinode_recruitment_apiTokenCheck();
+        $second = cinode_recruitment_apiTokenCheck();
+
+        $this->assertTrue($first);
+        $this->assertTrue($second);
+        // Only one HTTP call; second used the transient cache
+        $this->assertCount(1, $this->httpLog);
+    }
+
+    /* ==================================================================
+     * 12. cinode_recruitment_boundary()
+     * ================================================================*/
+
+    #[Test]
+    public function boundary_returns_64_char_alphanumeric_string(): void
+    {
+        $boundary = cinode_recruitment_boundary();
+
+        $this->assertSame(64, strlen($boundary));
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]+$/', $boundary);
+    }
+
+    #[Test]
+    public function boundary_returns_different_values_on_successive_calls(): void
+    {
+        $a = cinode_recruitment_boundary();
+        $b = cinode_recruitment_boundary();
+
+        $this->assertNotSame($a, $b);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Minimal WordPress function stubs so cinode-recruitment.php can be loaded
+ * without a full WordPress environment.
+ *
+ * Only the functions actually called by the code under test are stubbed.
+ */
+
+/* ---- constants ---- */
+if (!defined('WPINC')) {
+    define('WPINC', 'wp-includes');
+}
+
+/* ---- WordPress functions used by the plugin ---- */
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str) { return trim(strip_tags((string) $str)); }
+}
+
+if (!function_exists('sanitize_file_name')) {
+    /**
+     * Simplified stub of WP's sanitize_file_name():
+     * strips path, replaces whitespace, removes special chars.
+     */
+    function sanitize_file_name($name) {
+        $name = basename((string) $name);
+        $name = preg_replace('/[\s]+/', '-', $name);
+        $name = preg_replace('/[^A-Za-z0-9._\-]/', '', $name);
+        return $name;
+    }
+}
+
+if (!function_exists('sanitize_email')) {
+    function sanitize_email($email) { return filter_var((string) $email, FILTER_SANITIZE_EMAIL); }
+}
+
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($str) { return trim(strip_tags((string) $str)); }
+}
+
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($url) { return filter_var((string) $url, FILTER_SANITIZE_URL); }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $flags = 0) { return json_encode($data, $flags); }
+}
+
+if (!function_exists('wp_generate_password')) {
+    function wp_generate_password($length = 12, $special_chars = true, $extra_special_chars = false) {
+        return str_repeat('X', $length); // deterministic stub
+    }
+}
+
+/**
+ * get_option stub – returns a configurable array via a global.
+ */
+if (!function_exists('get_option')) {
+    function get_option($key, $default = false) {
+        return $GLOBALS['__wp_options'][$key] ?? $default;
+    }
+}
+
+/* ---- HTTP transport layer ---- */
+
+/**
+ * wp_remote_post / wp_remote_get stubs.
+ *
+ * When $GLOBALS['__pre_http_request'] is set to a callable, it receives
+ * ($url, $args) and must return a WP-style response array or a WP_Error.
+ * This mirrors WordPress's own `pre_http_request` filter pattern.
+ */
+
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        protected $code;
+        protected $message;
+        public function __construct($code = '', $message = '') {
+            $this->code    = $code;
+            $this->message = $message;
+        }
+        public function get_error_code() { return $this->code; }
+        public function get_error_message() { return $this->message; }
+    }
+}
+
+if (!class_exists('WP_REST_Response')) {
+    class WP_REST_Response {
+        public $data;
+        public $status;
+        public function __construct($data = null, $status = 200) {
+            $this->data   = $data;
+            $this->status = $status;
+        }
+    }
+}
+
+/**
+ * Minimal WP_REST_Request stand-in for testing.
+ * Supports array access (for $postData['field']) and get_file_params().
+ */
+class FakeWPRestRequest implements ArrayAccess {
+    private array $params;
+    private array $fileParams;
+
+    public function __construct(array $params = [], array $fileParams = []) {
+        $this->params     = $params;
+        $this->fileParams = $fileParams;
+    }
+
+    public function get_file_params(): array { return $this->fileParams; }
+
+    public function offsetExists(mixed $offset): bool { return isset($this->params[$offset]); }
+    public function offsetGet(mixed $offset): mixed    { return $this->params[$offset] ?? null; }
+    public function offsetSet(mixed $offset, mixed $value): void { $this->params[$offset] = $value; }
+    public function offsetUnset(mixed $offset): void   { unset($this->params[$offset]); }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) { return $thing instanceof WP_Error; }
+}
+
+function _cinode_test_dispatch_http($url, $args) {
+    if (isset($GLOBALS['__pre_http_request']) && is_callable($GLOBALS['__pre_http_request'])) {
+        return call_user_func($GLOBALS['__pre_http_request'], $url, $args);
+    }
+    // Default: return a 200 with empty body
+    return array(
+        'response' => array('code' => 200),
+        'body'     => '',
+    );
+}
+
+if (!function_exists('wp_remote_post')) {
+    function wp_remote_post($url, $args = array()) {
+        return _cinode_test_dispatch_http($url, $args);
+    }
+}
+
+if (!function_exists('wp_remote_get')) {
+    function wp_remote_get($url, $args = array()) {
+        return _cinode_test_dispatch_http($url, $args);
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_response_code')) {
+    function wp_remote_retrieve_response_code($response) {
+        if (is_wp_error($response)) {
+            return '';
+        }
+        return $response['response']['code'] ?? '';
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_body')) {
+    function wp_remote_retrieve_body($response) {
+        if (is_wp_error($response)) {
+            return '';
+        }
+        return $response['body'] ?? '';
+    }
+}
+
+/* ---- Hooks / shortcodes / misc stubs ---- */
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook($file, $cb) {}
+}
+if (!function_exists('register_deactivation_hook')) {
+    function register_deactivation_hook($file, $cb) {}
+}
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path($file) { return dirname($file) . '/'; }
+}
+if (!function_exists('register_rest_route')) {
+    function register_rest_route($ns, $route, $args) {}
+}
+if (!function_exists('add_action')) {
+    function add_action($hook, $cb, $prio = 10, $args = 1) {}
+}
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $cb, $prio = 10, $args = 1) {}
+}
+if (!function_exists('add_shortcode')) {
+    function add_shortcode($tag, $cb) {}
+}
+if (!function_exists('do_action')) {
+    function do_action($tag, ...$args) {}
+}
+if (!function_exists('wp_enqueue_style')) {
+    function wp_enqueue_style(...$args) {}
+}
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script(...$args) {}
+}
+if (!function_exists('add_options_page')) {
+    function add_options_page(...$args) {}
+}
+if (!function_exists('register_setting')) {
+    function register_setting(...$args) {}
+}
+if (!function_exists('load_plugin_textdomain')) {
+    function load_plugin_textdomain(...$args) {}
+}
+if (!function_exists('shortcode_atts')) {
+    function shortcode_atts($defaults, $atts, $shortcode = '') {
+        $out = $defaults;
+        foreach ($atts as $k => $v) {
+            if (array_key_exists($k, $out)) {
+                $out[$k] = $v;
+            }
+        }
+        return $out;
+    }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($text) { return htmlspecialchars((string)$text, ENT_QUOTES, 'UTF-8'); }
+}
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) { return htmlspecialchars((string)$text, ENT_QUOTES, 'UTF-8'); }
+}
+if (!function_exists('esc_url')) {
+    function esc_url($url) { return filter_var((string)$url, FILTER_SANITIZE_URL); }
+}
+if (!function_exists('wp_mail')) {
+    function wp_mail(...$args) {
+        $GLOBALS['__wp_mail_log'][] = $args;
+        return true;
+    }
+}
+if (!function_exists('set_transient')) {
+    function set_transient($key, $value, $expiration = 0) {
+        $GLOBALS['__wp_transients'][$key] = $value;
+        return true;
+    }
+}
+if (!function_exists('get_transient')) {
+    function get_transient($key) {
+        return $GLOBALS['__wp_transients'][$key] ?? false;
+    }
+}
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir() { return array('path' => sys_get_temp_dir(), 'url' => ''); }
+}
+if (!function_exists('wp_unique_filename')) {
+    function wp_unique_filename($dir, $name) { return $name; }
+}
+if (!function_exists('wp_delete_file')) {
+    function wp_delete_file($file) { @unlink($file); }
+}
+if (!function_exists('wp_check_filetype_and_ext')) {
+    function wp_check_filetype_and_ext($file, $filename, $mimes = null) {
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        return array('ext' => $ext, 'type' => 'application/octet-stream');
+    }
+}
+if (!defined('MINUTE_IN_SECONDS')) {
+    define('MINUTE_IN_SECONDS', 60);
+}
+
+/* ---- Autoload ---- */
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+/* ---- Load the plugin file ---- */
+require_once dirname(__DIR__) . '/cinode-recruitment.php';


### PR DESCRIPTION
This pull request introduces significant improvements to the admin interface for the Cinode Recruitment plugin. The main changes include the addition of a custom CSS stylesheet for the admin area, a new JavaScript file for enhanced tab navigation and copy-to-clipboard functionality, and the removal of boilerplate comments from the public-facing PHP class. These updates collectively enhance the user experience and maintainability of the plugin's admin and public interfaces.

**Admin UI Enhancements**

* Added a comprehensive custom stylesheet (`cinode-recruitment-admin.css`) for the admin area, introducing consistent styles for page wrappers, headers, badges, tab navigation, cards, form tables, code blocks, reference tables, inline notices, and step lists.
* Added a new JavaScript file (`cinode-recruitment-admin.js`) that implements tab navigation with session and URL hash persistence, and a robust copy-to-clipboard feature with fallback for legacy browsers.

**Codebase Cleanup**

* Removed boilerplate and demonstration comments from the `enqueue_styles` and `enqueue_scripts` methods in `class-cinode-recruitment-public.php`, making the code cleaner and easier to maintain. [[1]](diffhunk://#diff-c57125afe79efe1e82112a833f3adf3e0a4e8e9f4452c585568dad7cc2199559L64-L75) [[2]](diffhunk://#diff-c57125afe79efe1e82112a833f3adf3e0a4e8e9f4452c585568dad7cc2199559L87-L98)